### PR TITLE
feat: 대회 문제용 api 구현, consle.log 삭제, 파일 없을 시 예외처리, solutionCode 컬럼 추가

### DIFF
--- a/be/algo-with-me-api/src/competition/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/competition.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+import { CompetitionService } from './competition.service';
+
+@Controller('competitions')
+export class CompetitionController {
+  constructor(private readonly competitionService: CompetitionService) {}
+
+  @Get('problems/:id')
+  findOne(@Param('id') id: number) {
+    return this.competitionService.findOneProblem(id);
+  }
+}

--- a/be/algo-with-me-api/src/competition/competition.module.ts
+++ b/be/algo-with-me-api/src/competition/competition.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CompetitionController } from './competition.controller';
+import { CompetitionService } from './competition.service';
 import { Problem } from './entities/problem.entity';
 import { ProblemController } from './problem.controller';
 import { ProblemService } from './problem.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Problem])],
-  controllers: [ProblemController],
-  providers: [ProblemService],
+  controllers: [ProblemController, CompetitionController],
+  providers: [ProblemService, CompetitionService],
 })
 export class CompetitionModule {}

--- a/be/algo-with-me-api/src/competition/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/competition.service.ts
@@ -5,31 +5,13 @@ import { Repository } from 'typeorm';
 import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 
-import { CreateProblemDto } from './dto/create-problem.dto';
 import { Problem } from './entities/problem.entity';
 
 @Injectable()
-export class ProblemService {
+export class CompetitionService {
   constructor(@InjectRepository(Problem) private readonly problemRepository: Repository<Problem>) {}
 
-  create(createProblemDto: CreateProblemDto) {
-    const problem: Problem = createProblemDto.toEntity();
-
-    const savedProblem = this.problemRepository.save(problem);
-    return savedProblem;
-  }
-
-  async findAll() {
-    const problems = await this.problemRepository.find();
-    return problems.map((problem: Problem) => {
-      return {
-        id: problem.id,
-        title: problem.title,
-      };
-    });
-  }
-
-  async findOne(id: number) {
+  async findOneProblem(id: number) {
     const problem = await this.problemRepository.findOneBy({ id });
     const fileName = id.toString() + '.md';
     const paths = path.join(process.env.PROBLEM_PATH, id.toString(), fileName);
@@ -41,15 +23,9 @@ export class ProblemService {
       timeLimit: problem.timeLimit,
       memoryLimit: problem.memoryLimit,
       content: content,
+      solutionCode: problem.solutionCode,
+      testcases: '임시',
       createdAt: problem.createdAt,
     };
-  }
-
-  // update(id: number, updateCompetitionDto: UpdateCompetitionDto) {
-  //   return `This action updates a #${id} competition`;
-  // }
-
-  remove(id: number) {
-    this.problemRepository.delete({ id });
   }
 }

--- a/be/algo-with-me-api/src/competition/dto/create-problem.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/create-problem.dto.ts
@@ -18,6 +18,9 @@ export class CreateProblemDto {
   @IsNotEmpty()
   frameCode: string;
 
+  @IsNotEmpty()
+  solutionCode: string;
+
   toEntity(): Problem {
     const problem = new Problem();
     problem.title = this.title;
@@ -25,6 +28,7 @@ export class CreateProblemDto {
     problem.memoryLimit = this.memoryLimit;
     problem.testcaseNum = this.testcaseNum;
     problem.frameCode = this.frameCode;
+    problem.solutionCode = this.solutionCode;
     return problem;
   }
 }

--- a/be/algo-with-me-api/src/competition/entities/problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/problem.entity.ts
@@ -26,6 +26,9 @@ export class Problem {
   @Column('text')
   frameCode: string;
 
+  @Column('text')
+  solutionCode: string;
+
   @CreateDateColumn()
   createdAt: Date;
 


### PR DESCRIPTION
- 대회 문제용 api 구현했습니다. 사용자 에디터에 보여줄 솔루션 함수가 포함된 코드, 공개된 테스트 케이스가 기존 문제용 api에 추가로 들어갑니다.
- console.log 삭제했습니다.
- 파일 못찾을 시 예외처리 해주었습니다.
- 문제 엔티티에서 solutionCode를 추가해주었습니다.