### PR TITLE
[#23] 웹 워커 추가 & 코드 실행 환경 구성

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -17,6 +17,7 @@ module.exports = {
     'max-len': 'off',
     'operator-linebreak': 'off',
     indent: 'off',
+    'space-before-function-paren': 'off',
     'simple-import-sort/imports': [
       'error',
       {

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -21,7 +21,7 @@ module.exports = {
     'simple-import-sort/imports': [
       'error',
       {
-        groups: [['^.+\\.s?css$'], ['^react'], ['^@(/.*|$)']],
+        groups: [['^.+\\.s?css$', '^@style(/.*|$)'], ['^react'], ['^@(/.*|$)']],
       },
     ],
   },

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,7 +2,6 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
 }
 
 .logo {

--- a/frontend/src/components/ContestPage.tsx
+++ b/frontend/src/components/ContestPage.tsx
@@ -1,13 +1,21 @@
 import { useState } from 'react';
 
 import Editor from './Editor';
+import Tester from './Tester';
 
 const ContestPage = () => {
-  const [code, setCode] = useState(localStorage.getItem('myValue') || 'function solution() {\n\n}');
+  const [code, setCode] = useState<string>(
+    localStorage.getItem('myValue') || 'function solution() {\n\n}',
+  );
+
+  const handleChangeCode = (newCode: string) => {
+    setCode(newCode);
+  };
 
   return (
     <div>
-      <Editor code={code} setCode={setCode} />
+      <Editor code={code} onChangeCode={handleChangeCode} />
+      <Tester code={code}></Tester>
     </div>
   );
 };

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -10,7 +10,7 @@ const style = {
 
 interface Props {
   code: string;
-  setCode: (newCode: string) => void;
+  onChangeCode: (newCode: string) => void;
 }
 
 const Editor = (props: Props) => {
@@ -23,7 +23,7 @@ const Editor = (props: Props) => {
       extensions={[javascript()]}
       initialState={undefined}
       onChange={(value) => {
-        props.setCode(value);
+        props.onChangeCode(value);
       }}
     />
   );

--- a/frontend/src/components/Tester.tsx
+++ b/frontend/src/components/Tester.tsx
@@ -1,0 +1,49 @@
+import { css } from '@style/css';
+
+import type { ChangeEvent, HTMLAttributes } from 'react';
+import { useEffect, useState } from 'react';
+
+import evaluator, { type EvalResult } from '@/modules/evaluator';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  code: string;
+}
+
+export default function Tester(props: Props) {
+  const { code } = props;
+
+  const [result, setResult] = useState<string | number>();
+  const [param, setParam] = useState<string>('');
+
+  const handleParamChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newParam = e.target.value;
+    setParam(newParam);
+  };
+
+  const handleEvalResult = (response: EvalResult) => {
+    if (!response) return;
+
+    const result = response.result as string;
+    setResult(result);
+  };
+
+  useEffect(() => {
+    return evaluator.subscribe(handleEvalResult);
+  }, []);
+
+  const handleTestExec = () => {
+    evaluator.safeEval(code, param);
+  };
+
+  return (
+    <div>
+      <input className={inputStyle} onChange={handleParamChange} value={param}></input>
+      <button onClick={handleTestExec}>테스트 실행</button>
+      <p>result: {result}</p>
+    </div>
+  );
+}
+
+const inputStyle = css({
+  border: '1px solid black',
+});

--- a/frontend/src/modules/evaluator/eval.worker.ts
+++ b/frontend/src/modules/evaluator/eval.worker.ts
@@ -1,0 +1,19 @@
+import evalCode from './evalCode';
+import type { EvalMessage } from './types';
+
+type MessageEvent = {
+  data: EvalMessage;
+};
+
+self.addEventListener('message', async function (e: MessageEvent) {
+  const message = e.data;
+
+  try {
+    const { code, param } = message;
+    const result = evalCode(code, param);
+
+    self.postMessage(result);
+  } catch (err) {
+    self.postMessage(err);
+  }
+});

--- a/frontend/src/modules/evaluator/evalCode.ts
+++ b/frontend/src/modules/evaluator/evalCode.ts
@@ -1,0 +1,12 @@
+import { EvalResult } from './types';
+
+export default function evalCode(code: string, params: string): EvalResult {
+  /**
+   * @notice 단순하게 코드 실행을 구현하기 위해 임시적으로 eval을 사용하며 다음 테스크에서 eval을 제거하고 quickJS로 대체할 예정입니다.
+   */
+  const result = eval(`${code}\nsolution(${params})`);
+
+  return {
+    result,
+  };
+}

--- a/frontend/src/modules/evaluator/index.ts
+++ b/frontend/src/modules/evaluator/index.ts
@@ -1,0 +1,41 @@
+import type { EvalResult } from './types';
+
+type WorkerListener = (args: EvalResult) => void;
+
+const evalWorker = new Worker(new URL('./eval.worker.ts', import.meta.url), {
+  type: 'module',
+});
+
+let listeners: WorkerListener[] = [];
+
+evalWorker.addEventListener('message', ({ data }) => {
+  notify(data);
+});
+
+function notify(data: EvalResult) {
+  listeners.forEach((l) => l(data));
+}
+
+function safeEval(code: string, param: string) {
+  const message = {
+    code,
+    param,
+  };
+
+  evalWorker.postMessage(message);
+}
+
+function subscribe(listener: WorkerListener) {
+  listeners.push(listener);
+
+  return () => {
+    listeners = listeners.filter((l) => l !== listener);
+  };
+}
+
+export default {
+  safeEval,
+  subscribe,
+};
+
+export * from './types';

--- a/frontend/src/modules/evaluator/types.ts
+++ b/frontend/src/modules/evaluator/types.ts
@@ -1,0 +1,9 @@
+export type EvalMessage = {
+  type: 'EVAL';
+  code: string;
+  param: string;
+};
+
+export type EvalResult = {
+  result: unknown;
+};


### PR DESCRIPTION
## 변경 사항
- web worker 1개가 추가되었으며 이를 통해 입력된 코드를 수행할 수 있습니다.
  - 일단 eval을 사용하도록 구현하였으며 다음 스프린트를 통해 QuickJS로 교체할 예정입니다.
- @style이 import의 최상위에 오도록 lint 규칙을 변경했습니다.
  - [결정 참고](https://boostcampwm-8-me.slack.com/archives/C0615MFR0V7/p1700103597517249) 
- eslint에 `'space-before-function-paren':'off'`를 추가했습니다.  
  - prettier와의 중복으로 인해 아래의 충돌 현상이 있었고, 이를 위해 lint의 규칙을 껐습니다. 
- index.css에서 모든 텍스트를 중앙정렬하는 옵션이 있었는데 이 때문에 codemirror도 중앙정렬이 되는 문제가 있어 제거했습니다.

```ts
// space before function paren 옵션은 function 이름과 파라미터 사이에 공백을 넣도록 하는 옵션입니다.
// 이는 prettier에서 공백을 빼는 규칙과 충돌하여 껐습니다.

function something() { // 여기서 something 다음에 공백을 넣도록 강제하는 옵션을 끔
  // ...
}
```

## 스크린 샷
![runexample](https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/9ebeb1d7-98c6-48f6-9bcf-ee62635c5a87)
코드를 입력하고 파라미터를 넣으면 코드를 수행할 수 있습니다.