### PR TITLE
api 서버에서 채점 결과 받아서 client에게 전송하는 것 구현

### DIFF
--- a/be/algo-with-me-api/src/competition/competition.enums.ts
+++ b/be/algo-with-me-api/src/competition/competition.enums.ts
@@ -1,7 +1,7 @@
 export const RESULT = {
   PROGRESS: '처리중',
   CORRECT: '정답입니다',
-  WRONG: '오답입니다.',
+  WRONG: '오답입니다',
   TIMEOUT: '시간초과',
   OOM: '메모리초과',
 } as const;

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UsePipes, ValidationPipe } from '@nestjs/common';
 
+import { ScoreResultDto } from '../dto/score-result.dto';
 import { CompetitionService } from '../services/competition.service';
 
 @Controller('competitions')
@@ -9,6 +10,12 @@ export class CompetitionController {
   @Get('problems/:id')
   findOne(@Param('id') id: number) {
     return this.competitionService.findOneProblem(id);
+  }
+
+  @Post('scores')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  saveScoreResult(@Body() scoreResultDto: ScoreResultDto) {
+    this.competitionService.saveScoreResult(scoreResultDto);
   }
 
   // @Post('submissions')

--- a/be/algo-with-me-api/src/competition/dto/score-result.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/score-result.dto.ts
@@ -1,0 +1,22 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+
+import { RESULT } from '../competition.enums';
+
+export class ScoreResultDto {
+  @IsNotEmpty()
+  submissionId: number;
+
+  @IsNotEmpty()
+  problemId: number;
+
+  @IsNotEmpty()
+  testcaseId: number;
+
+  @IsNotEmpty()
+  socketId: string;
+
+  @IsEnum(RESULT)
+  result: string;
+
+  stdOut: string;
+}

--- a/be/algo-with-me-api/src/competition/entities/submission.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/submission.entity.ts
@@ -25,8 +25,8 @@ export class Submission {
   })
   result: string;
 
-  @Column('json', { nullable: true })
-  detail: string;
+  @Column('json', { nullable: true, default: [] })
+  detail: object[];
 
   @ManyToOne(() => Problem, (problem) => problem.submissions, { nullable: false })
   problem: Problem;

--- a/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
+++ b/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
@@ -25,17 +25,17 @@ export class CompetitionGateWay implements OnGatewayConnection, OnGatewayInit {
     this.competitionService.server = server;
   }
 
-  @SubscribeMessage('events')
-  handleEvent(@MessageBody() data: string, @ConnectedSocket() client: Socket): WsResponse<unknown> {
-    this.server.emit('events', { data: '데이터 간다' });
-    client.emit('events', { data: '데이터 간다22' });
-    this.server.to(client.id).emit('events', { data: '데이터 간다 33' });
-    const event = 'events';
-    console.log(client.id);
-    console.log(client.rooms);
-    console.log(data);
-    return { event, data };
-  }
+  // @SubscribeMessage('events')
+  // handleEvent(@MessageBody() data: string, @ConnectedSocket() client: Socket): WsResponse<unknown> {
+  //   this.server.emit('events', { data: '데이터 간다' });
+  //   client.emit('events', { data: '데이터 간다22' });
+  //   this.server.to(client.id).emit('events', { data: '데이터 간다 33' });
+  //   const event = 'events';
+  //   console.log(client.id);
+  //   console.log(client.rooms);
+  //   console.log(data);
+  //   return { event, data };
+  // }
 
   @SubscribeMessage('submissions')
   @UsePipes(new ValidationPipe({ transform: true }))
@@ -44,9 +44,9 @@ export class CompetitionGateWay implements OnGatewayConnection, OnGatewayInit {
     @ConnectedSocket() client: Socket,
   ): WsResponse<unknown> {
     this.competitionService.scoreSubmission(createSubmissionDto, client.id);
-    console.log(createSubmissionDto);
     const event = 'messages';
     const data = { message: '채점을 시작합니다.' };
+    console.log(createSubmissionDto);
     return { event, data };
   }
 

--- a/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
+++ b/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
@@ -23,7 +23,9 @@ export class CompetitionGateWay implements OnGatewayConnection {
   handleEvent(@MessageBody() data: string, @ConnectedSocket() client: Socket): WsResponse<unknown> {
     this.server.emit('events', { data: '데이터 간다' });
     client.emit('events', { data: '데이터 간다22' });
+    this.server.to(client.id).emit('events', { data: '데이터 간다 33' });
     const event = 'events';
+    console.log(client.id);
     console.log(client.rooms);
     console.log(data);
     return { event, data };
@@ -34,7 +36,7 @@ export class CompetitionGateWay implements OnGatewayConnection {
     @MessageBody() createSubmissionDto: CreateSubmissionDto,
     @ConnectedSocket() client: Socket,
   ) {
-    this.competitionService.scoreSubmission(createSubmissionDto);
+    this.competitionService.scoreSubmission(createSubmissionDto, client.id);
     client.emit('message', { message: '채점을 시작합니다.' });
     console.log(createSubmissionDto, client);
   }
@@ -43,7 +45,6 @@ export class CompetitionGateWay implements OnGatewayConnection {
     // TODO: 사용자가 대회 참여중인지 확인하는 로직 추가해야 함
     const { competitionId } = client.handshake.query;
     client.join(competitionId);
-    client.leave(client.id);
     console.log(competitionId, args);
   }
 }

--- a/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
+++ b/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
@@ -38,6 +38,7 @@ export class CompetitionGateWay implements OnGatewayConnection, OnGatewayInit {
   // }
 
   @SubscribeMessage('submissions')
+  // TODO: 검증 실패시 에러 터져버리고, websocket으로 internal server error 가는거 수정해야됨.
   @UsePipes(new ValidationPipe({ transform: true }))
   handleSubmission(
     @MessageBody() createSubmissionDto: CreateSubmissionDto,

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -1,18 +1,24 @@
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { WebSocketServer } from '@nestjs/websockets';
 import { Queue } from 'bull';
+import { Server } from 'socket.io';
 import { Repository } from 'typeorm';
 
 import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 
 import { CreateSubmissionDto } from '../dto/create-submission.dto';
+import { ScoreResultDto } from '../dto/score-result.dto';
 import { Problem } from '../entities/problem.entity';
 import { Submission } from '../entities/submission.entity';
 
 @Injectable()
 export class CompetitionService {
+  @WebSocketServer()
+  server: Server;
+
   constructor(
     @InjectRepository(Problem) private readonly problemRepository: Repository<Problem>,
     @InjectRepository(Submission) private readonly submissionRepository: Repository<Submission>,
@@ -50,5 +56,24 @@ export class CompetitionService {
     });
 
     return savedSubmission;
+  }
+
+  async saveScoreResult(scoreResultDto: ScoreResultDto) {
+    const submission = await this.submissionRepository.findOneBy({
+      id: scoreResultDto.submissionId,
+    });
+    if (!submission) throw new NotFoundException('제출 기록이 없습니다.');
+
+    const result = {
+      testcaseId: scoreResultDto.testcaseId,
+      result: scoreResultDto.result,
+      stdOut: scoreResultDto.stdOut,
+    };
+
+    submission.detail.push(result);
+    this.submissionRepository.save(submission);
+
+    result['problemId'] = scoreResultDto.problemId;
+    this.server.to(scoreResultDto.socketId).emit("message", result);
   }
 }

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -55,6 +55,7 @@ export class CompetitionService {
     return savedSubmission;
   }
 
+  // TODO: 유저, 대회 도메인 구현 이후 수정 필요
   async saveScoreResult(scoreResultDto: ScoreResultDto) {
     const submission = await this.submissionRepository.findOneBy({
       id: scoreResultDto.submissionId,

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -1,7 +1,6 @@
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { WebSocketServer } from '@nestjs/websockets';
 import { Queue } from 'bull';
 import { Server } from 'socket.io';
 import { Repository } from 'typeorm';
@@ -16,9 +15,7 @@ import { Submission } from '../entities/submission.entity';
 
 @Injectable()
 export class CompetitionService {
-  @WebSocketServer()
   server: Server;
-
   constructor(
     @InjectRepository(Problem) private readonly problemRepository: Repository<Problem>,
     @InjectRepository(Submission) private readonly submissionRepository: Repository<Submission>,
@@ -67,13 +64,13 @@ export class CompetitionService {
     const result = {
       testcaseId: scoreResultDto.testcaseId,
       result: scoreResultDto.result,
-      stdOut: scoreResultDto.stdOut,
     };
 
     submission.detail.push(result);
     this.submissionRepository.save(submission);
 
     result['problemId'] = scoreResultDto.problemId;
-    this.server.to(scoreResultDto.socketId).emit("message", result);
+    result['stdOut'] = scoreResultDto.stdOut;
+    this.server.to(scoreResultDto.socketId).emit('messages', result);
   }
 }

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -71,6 +71,6 @@ export class CompetitionService {
 
     result['problemId'] = scoreResultDto.problemId;
     result['stdOut'] = scoreResultDto.stdOut;
-    this.server.to(scoreResultDto.socketId).emit('messages', result);
+    this.server.to(scoreResultDto.socketId).emit('scoreResult', result);
   }
 }

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -37,7 +37,7 @@ export class CompetitionService {
     };
   }
 
-  async scoreSubmission(createSubmissionDto: CreateSubmissionDto) {
+  async scoreSubmission(createSubmissionDto: CreateSubmissionDto, socketId: string) {
     const problem: Problem = await this.problemRepository.findOneBy({
       id: createSubmissionDto.problemId,
     });
@@ -46,6 +46,7 @@ export class CompetitionService {
     await this.submissionQueue.add({
       problemId: savedSubmission.problem.id,
       submissionId: savedSubmission.id,
+      socketId: socketId,
     });
 
     return savedSubmission;


### PR DESCRIPTION
- redis queue에 들어가는 데이터에 socketId를 추가했습니다.
- 
- 채점 서버에서 테스트 케이스 채점 완료시 호출할 api를 구현하였습니다.
    - submission entity의 json 기본 값을 []로 했습니다.
    - 채점 결과를 db에 저장합니다.
    - 채점 결과를 websocket을 통해 client에게 전송합니다.
    - 서비스 로직에서 socket 정보를 갖고 있게 하기 위해 CompetitionGateWay에 afterInit메서드를 구현하였습니다.
- 테스트용으로 사용했던 코드를 주석 처리했습니다. 추후 참고하려고 놔두었는데, 필요없다고 판단되면 추후 삭제하겠습니다.
- 유저, 대회가 구현이 안되서 나중에 추가해야 될 것들을 todo로 작성해놨습니다.