### PR TITLE
[#59] 대회 정보 api - create read update 구현

### DIFF
--- a/be/algo-with-me-api/src/app.module.ts
+++ b/be/algo-with-me-api/src/app.module.ts
@@ -7,6 +7,8 @@ import { CompetitionModule } from './competition/competition.module';
 import { Problem } from './competition/entities/problem.entity';
 import { Submission } from './competition/entities/submission.entity';
 
+import { Competition } from '@src/competition/entities/competition.entity';
+
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -21,7 +23,7 @@ import { Submission } from './competition/entities/submission.entity';
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       synchronize: true,
-      entities: [Problem, Submission],
+      entities: [Problem, Submission, Competition],
     }),
     BullModule.forRoot({
       redis: {

--- a/be/algo-with-me-api/src/competition/competition.module.ts
+++ b/be/algo-with-me-api/src/competition/competition.module.ts
@@ -11,9 +11,11 @@ import { CompetitionService } from './services/competition.service';
 import { ProblemService } from './services/problem.service';
 import { SubmissionConsumer } from './tem.consumer';
 
+import { Competition } from '@src/competition/entities/competition.entity';
+
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Problem, Submission]),
+    TypeOrmModule.forFeature([Problem, Submission, Competition]),
     BullModule.registerQueue({
       name: process.env.REDIS_MESSAGE_QUEUE_NAME,
     }),

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -1,19 +1,59 @@
-import { Body, Controller, Get, Param, Post, UsePipes, ValidationPipe } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Post,
+  Put,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { CompetitionProblemResponseDto } from '../dto/competition.problem.response.dto';
+import { CreateCompetitionDto } from '../dto/create-competition.dto';
 import { ScoreResultDto } from '../dto/score-result.dto';
+import { UpdateCompetitionDto } from '../dto/update-competition.dto';
 import { CompetitionService } from '../services/competition.service';
+
+import { CompetitionResponseDto } from '@src/competition/dto/competition.response.dto';
 
 @ApiTags('대회(competitions)')
 @Controller('competitions')
 export class CompetitionController {
   constructor(private readonly competitionService: CompetitionService) {}
 
+  @Get('/:id')
+  @ApiOperation({ summary: '대회 정보 조회' })
+  @ApiResponse({ type: CompetitionResponseDto })
+  async findOne(@Param('id') id: number) {
+    return await this.competitionService.findOne(id);
+  }
+
+  @Post('/')
+  @ApiOperation({ summary: '대회 생성' })
+  @ApiResponse({ type: CompetitionResponseDto })
+  @UsePipes(new ValidationPipe({ transform: true }))
+  create(@Body() createCompetitionDto: CreateCompetitionDto) {
+    return this.competitionService.create(createCompetitionDto);
+  }
+
+  @Put('/:id')
+  @ApiOperation({
+    summary: '대회 정보 수정',
+    description: `URL의 파라미터(/:id)로 주어진 대회 id에 해당하는 대회 정보를 수정한다.`,
+  })
+  @ApiResponse({})
+  @UsePipes(new ValidationPipe({ transform: true }))
+  update(@Param('id') id: number, @Body() updateCompetitionDto: UpdateCompetitionDto) {
+    return this.competitionService.update(id, updateCompetitionDto);
+  }
+
   @Get('problems/:id')
   @ApiOperation({ summary: '대회 문제 상세 조회' })
   @ApiResponse({ type: CompetitionProblemResponseDto })
-  findOne(@Param('id') id: number) {
+  findOneProblem(@Param('id') id: number) {
     return this.competitionService.findOneProblem(id);
   }
 

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -1,14 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Logger,
-  Param,
-  Post,
-  Put,
-  UsePipes,
-  ValidationPipe,
-} from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { CompetitionProblemResponseDto } from '../dto/competition.problem.response.dto';

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -40,7 +40,7 @@ export class CompetitionController {
     summary: '대회 정보 수정',
     description: `URL의 파라미터(\`/:id\`)로 주어진 대회 id에 해당하는 대회 정보를 수정한다. request JSON 중 **수정하기를 원하는 것만** key: value 형식으로 요청한다.`,
   })
-  @ApiResponse({})
+  @ApiResponse({ type: Boolean })
   @UsePipes(new ValidationPipe({ transform: true }))
   update(@Param('id') id: number, @Body() updateCompetitionDto: UpdateCompetitionDto) {
     return this.competitionService.update(id, updateCompetitionDto);

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -25,14 +25,20 @@ export class CompetitionController {
   constructor(private readonly competitionService: CompetitionService) {}
 
   @Get('/:id')
-  @ApiOperation({ summary: '대회 정보 조회' })
+  @ApiOperation({
+    summary: '대회 정보 조회',
+    description: 'URL의 파라미터(`/:id`)로 주어진 대회 id에 해당하는 대회 정보를 조회한다.',
+  })
   @ApiResponse({ type: CompetitionResponseDto })
   async findOne(@Param('id') id: number) {
     return await this.competitionService.findOne(id);
   }
 
   @Post('/')
-  @ApiOperation({ summary: '대회 생성' })
+  @ApiOperation({
+    summary: '대회 생성',
+    description: `주어진 대회 관련 정보를 이용해 대회를 생성한다.`,
+  })
   @ApiResponse({ type: CompetitionResponseDto })
   @UsePipes(new ValidationPipe({ transform: true }))
   create(@Body() createCompetitionDto: CreateCompetitionDto) {
@@ -42,7 +48,7 @@ export class CompetitionController {
   @Put('/:id')
   @ApiOperation({
     summary: '대회 정보 수정',
-    description: `URL의 파라미터(/:id)로 주어진 대회 id에 해당하는 대회 정보를 수정한다.`,
+    description: `URL의 파라미터(\`/:id\`)로 주어진 대회 id에 해당하는 대회 정보를 수정한다. request JSON 중 **수정하기를 원하는 것만** key: value 형식으로 요청한다.`,
   })
   @ApiResponse({})
   @UsePipes(new ValidationPipe({ transform: true }))
@@ -59,8 +65,9 @@ export class CompetitionController {
 
   @Post('scores')
   @ApiOperation({
-    summary: '채점 서버에서 채점 완료시 요청받을 api',
-    description: '채점 서버에서 테스트케이스 별로 채점이 완료될경우 호출할 api',
+    summary: '[백엔드 전용] 채점 서버에서 채점 완료시 요청받을 api',
+    description:
+      '**[프론트엔드에서는 사용되지 않음. 백엔드에서만 사용됨]** 채점 서버에서 테스트케이스 별로 채점이 완료될경우 호출할 api',
   })
   @UsePipes(new ValidationPipe({ transform: true }))
   saveScoreResult(@Body() scoreResultDto: ScoreResultDto) {

--- a/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+export class CompetitionResponseDto {
+  @ApiProperty({ description: '대회 id' })
+  @IsNotEmpty()
+  id: number;
+
+  @ApiProperty({ description: '대회 이름' })
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: '대회에 대한 설명글' })
+  @IsNotEmpty()
+  detail: string;
+
+  @ApiProperty({ description: '대회에 참여 가능한 최대 인원' })
+  @IsNotEmpty()
+  maxParticipants: number;
+
+  @ApiProperty({ description: '대회 시작 일시 (ISO string)' })
+  @IsNotEmpty()
+  startsAt: string;
+
+  @ApiProperty({ description: '대회 종료 일시 (ISO string)' })
+  @IsNotEmpty()
+  endsAt: string;
+
+  @ApiProperty({ description: '레코드 생성 일시 (ISO string)' })
+  @IsNotEmpty()
+  createdAt: string;
+
+  @ApiProperty({ description: '레코드 수정 일시 (ISO string)' })
+  @IsNotEmpty()
+  updatedAt: string;
+}

--- a/be/algo-with-me-api/src/competition/dto/create-competition.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/create-competition.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+import { Competition } from '@src/competition/entities/competition.entity';
+
+export class CreateCompetitionDto {
+  @ApiProperty({ description: '대회 이름' })
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: '대회에 대한 설명글' })
+  @IsNotEmpty()
+  detail: string;
+
+  @ApiProperty({ description: '대회에 참여 가능한 최대 인원' })
+  @IsNotEmpty()
+  maxParticipants: number;
+
+  @ApiProperty({ description: '대회 시작 일시 (ISO string)' })
+  @IsNotEmpty()
+  startsAt: string;
+
+  @ApiProperty({ description: '대회 종료 일시 (ISO string)' })
+  @IsNotEmpty()
+  endsAt: string;
+
+  toEntity(): Competition {
+    const competition = new Competition();
+    competition.name = this.name;
+    competition.detail = this.detail;
+    competition.maxParticipants = this.maxParticipants;
+    competition.startsAt = new Date(this.startsAt);
+    competition.endsAt = new Date(this.endsAt);
+    return competition;
+  }
+}

--- a/be/algo-with-me-api/src/competition/dto/update-competition.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/update-competition.dto.ts
@@ -1,0 +1,36 @@
+import { Optional } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Competition } from '@src/competition/entities/competition.entity';
+
+export class UpdateCompetitionDto {
+  @ApiProperty({ description: '대회 이름' })
+  @Optional()
+  name: string;
+
+  @ApiProperty({ description: '대회에 대한 설명글' })
+  @Optional()
+  detail: string;
+
+  @ApiProperty({ description: '대회에 참여 가능한 최대 인원' })
+  @Optional()
+  maxParticipants: number;
+
+  @ApiProperty({ description: '대회 시작 일시 (ISO string)' })
+  @Optional()
+  startsAt: string;
+
+  @ApiProperty({ description: '대회 종료 일시 (ISO string)' })
+  @Optional()
+  endsAt: string;
+
+  toEntity(): Competition {
+    const competition = new Competition();
+    competition.name = this.name;
+    competition.detail = this.detail;
+    competition.maxParticipants = this.maxParticipants;
+    competition.startsAt = new Date(this.startsAt);
+    competition.endsAt = new Date(this.endsAt);
+    return competition;
+  }
+}

--- a/be/algo-with-me-api/src/competition/entities/competition.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.entity.ts
@@ -19,10 +19,6 @@ export class Competition {
   @ApiProperty({ description: '대회 id' })
   id: number;
 
-  @ApiProperty({ description: '대회를 개최한 유저의 id' })
-  @Column()
-  userId: number;
-
   @ApiProperty({ description: '대회 이름' })
   @Column()
   name: string;

--- a/be/algo-with-me-api/src/competition/entities/competition.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.entity.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { Problem } from './problem.entity';
+import { Submission } from './submission.entity';
+
+@Entity()
+export class Competition {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ description: '대회 id' })
+  id: number;
+
+  @ApiProperty({ description: '대회를 개최한 유저의 id' })
+  @Column()
+  userId: number;
+
+  @ApiProperty({ description: '대회 이름' })
+  @Column()
+  name: string;
+
+  @ApiProperty({ description: '대회에 대한 설명글' })
+  @Column('text')
+  detail: string;
+
+  @ApiProperty({ description: '대회에 참여 가능한 최대 인원' })
+  @Column()
+  maxParticipants: number;
+
+  @ApiProperty({ description: '대회 시작 일시' })
+  @Column()
+  startsAt: Date;
+
+  @ApiProperty({ description: '대회 종료 일시' })
+  @Column()
+  endsAt: Date;
+
+  @ApiProperty({ description: '제출(submission) 테이블과 일대다 관계' })
+  @OneToMany(() => Submission, (submission) => submission.competition)
+  submissions: Submission[];
+
+  @ApiProperty({ description: '문제(problem) 테이블과 다대다 관계' })
+  @ManyToMany(() => Problem, (problem) => problem.competitions)
+  @JoinTable({
+    name: 'CompetitionProblem',
+    joinColumn: { name: 'competitionId', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'problemId', referencedColumnName: 'id' },
+  })
+  problems: Problem[];
+
+  @ApiProperty({ description: '레코드 생성 일시' })
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ApiProperty({ description: '레코드 수정 일시' })
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/be/algo-with-me-api/src/competition/entities/problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/problem.entity.ts
@@ -3,11 +3,14 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  ManyToMany,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
+  JoinTable,
 } from 'typeorm';
 
+import { Competition } from './competition.entity';
 import { Submission } from './submission.entity';
 
 @Entity()
@@ -43,6 +46,15 @@ export class Problem {
   @ApiProperty()
   @OneToMany(() => Submission, (submission) => submission.problem)
   submissions: Submission[];
+
+  @ApiProperty()
+  @ManyToMany(() => Competition, (competition) => competition.problems)
+  @JoinTable({
+    name: 'CompetitionProblem',
+    joinColumn: { name: 'problemId', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'competitionId', referencedColumnName: 'id' },
+  })
+  competitions: Competition[];
 
   @ApiProperty()
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/entities/submission.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/submission.entity.ts
@@ -7,6 +7,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { Competition } from './competition.entity';
 import { Problem } from './problem.entity';
 import { RESULT } from '../competition.enums';
 
@@ -30,6 +31,9 @@ export class Submission {
 
   @ManyToOne(() => Problem, (problem) => problem.submissions, { nullable: false })
   problem: Problem;
+
+  @ManyToOne(() => Competition, (competition) => competition.submissions)
+  competition: Competition;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -1,5 +1,5 @@
 import { InjectQueue } from '@nestjs/bull';
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Queue } from 'bull';
 import { Server } from 'socket.io';


### PR DESCRIPTION
대회 정보 API 작성했습니다. (delete 제외, CRU)

User 엔티티가 만들어지면, 다음 작업들이 필요합니다

1. User와 Competition과의 관계 설정
2. API 반환값 일부 변경 (userId(대회 출제자의 id)까지 반환) 