### PR TITLE
[#91] 문제 보기 api 연동

### DIFF
--- a/frontend/src/hooks/competition/useCompetition.ts
+++ b/frontend/src/hooks/competition/useCompetition.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+interface Competition {
+  id: number;
+  name: string;
+  detail: string;
+  maxParticipants: number;
+  startsAt: string;
+  endsAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const notFoundCompetition: Competition = {
+  id: 0,
+  name: 'Competition Not Found',
+  detail: 'Competition Not Found',
+  maxParticipants: 0,
+  startsAt: 'Competition Not Found',
+  endsAt: 'Competition Not Found',
+  createdAt: 'Competition Not Found',
+  updatedAt: 'Competition Not Found',
+};
+
+export const useCompetition = (competitionId: number) => {
+  const problems = [1, 2, 3]; // TODO: 대회에 해당하는 문제의 id를 유동적으로 채워넣을 수 있게 수정해야함
+  const [competition, setCompetition] = useState<Competition>(notFoundCompetition);
+
+  useEffect(() => {
+    axios
+      .get(`http://101.101.208.240:3000/competitions/${competitionId}`)
+      .then((response) => {
+        setCompetition(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching competition data:', error);
+      });
+  }, [competitionId]);
+
+  return {
+    problems,
+    competition,
+  };
+};

--- a/frontend/src/hooks/problem/useProblem.ts
+++ b/frontend/src/hooks/problem/useProblem.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+interface CompetitionProblem {
+  id: number;
+  title: string;
+  timeLimit: number;
+  memoryLimit: number;
+  content: string;
+  createdAt: string;
+  solutionCode: string;
+  testcases: string;
+}
+
+const notFoundProblem: CompetitionProblem = {
+  id: 0,
+  title: 'Problem Not Found',
+  timeLimit: 0,
+  memoryLimit: 0,
+  content: 'The requested problem could not be found.',
+  solutionCode: '',
+  testcases: '',
+  createdAt: new Date().toISOString(),
+};
+
+export const useProblem = (problemId: number) => {
+  const [problem, setProblem] = useState<CompetitionProblem>(notFoundProblem);
+
+  useEffect(() => {
+    const fetchProblem = async () => {
+      try {
+        const response = await axios.get(
+          `http://101.101.208.240:3000/competitions/problems/${problemId}`,
+        );
+        const problem = response.data;
+        setProblem(problem || [notFoundProblem]);
+      } catch (error) {
+        console.error('Error fetching problem data:', error);
+      }
+    };
+    fetchProblem();
+  }, [problemId]);
+
+  return {
+    problem,
+  };
+};

--- a/frontend/src/hooks/problem/useProblem.ts
+++ b/frontend/src/hooks/problem/useProblem.ts
@@ -27,19 +27,18 @@ const notFoundProblem: CompetitionProblem = {
 export const useProblem = (problemId: number) => {
   const [problem, setProblem] = useState<CompetitionProblem>(notFoundProblem);
 
+  const fetchProblem = async (id: number) => {
+    try {
+      const response = await axios.get(`http://101.101.208.240:3000/competitions/problems/${id}`);
+      const fetchedProblem = response.data;
+      setProblem(fetchedProblem || notFoundProblem);
+    } catch (error) {
+      console.error('Error fetching problem data:', error);
+    }
+  };
+
   useEffect(() => {
-    const fetchProblem = async () => {
-      try {
-        const response = await axios.get(
-          `http://101.101.208.240:3000/competitions/problems/${problemId}`,
-        );
-        const problem = response.data;
-        setProblem(problem || [notFoundProblem]);
-      } catch (error) {
-        console.error('Error fetching problem data:', error);
-      }
-    };
-    fetchProblem();
+    fetchProblem(problemId);
   }, [problemId]);
 
   return {

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -25,7 +25,7 @@ interface Competition {
   updatedAt: string;
 }
 
-interface Problem {
+interface CompetitionProblem {
   id: number;
   title: string;
   timeLimit: number;
@@ -47,7 +47,7 @@ const notFoundCompetition: Competition = {
   updatedAt: 'Competition Not Found',
 };
 
-const notFoundProblem: Problem = {
+const notFoundProblem: CompetitionProblem = {
   id: 0,
   title: 'Problem Not Found',
   timeLimit: 0,
@@ -71,12 +71,12 @@ export default function ContestPage() {
     cancelSimulation,
   } = useSimulations();
   const { id } = useParams<{ id: string }>();
-  const competitionId = id ? parseInt(id, 10) : null;
+  const competitionId: number = id ? parseInt(id, 10) : -1;
   const [competition, setCompetition] = useState<Competition | null>(notFoundCompetition);
   const currentProblemId = 0; // TODO: 문제 선택 로직 작성시 currentProblemId를 바꿀 수 있게 해야함
 
   const problems = [1, 2, 3]; // TODO: 대회에 해당하는 문제의 id를 유동적으로 채워넣을 수 있게 수정해야함
-  const [problemList, setProblemList] = useState<Problem[]>([notFoundProblem]);
+  const [problemList, setProblemList] = useState<CompetitionProblem[]>([notFoundProblem]);
 
   const [code, setCode] = useState<string>(notFoundProblem.solutionCode);
 
@@ -116,7 +116,7 @@ export default function ContestPage() {
       try {
         const responses = await Promise.all(problemRequests);
         const newProblemList = responses.map((response) => response.data);
-        setProblemList(newProblemList || notFoundProblem);
+        setProblemList(newProblemList || [notFoundProblem]);
       } catch (error) {
         console.error('Error fetching problem data:', error);
       }
@@ -125,25 +125,19 @@ export default function ContestPage() {
     fetchProblems();
   }, []);
 
-  const crumbs = [
-    SITE.NAME,
-    competition?.name || notFoundCompetition.name,
-    problemList[currentProblemId].title,
-  ];
+  const currentProblem = problemList[currentProblemId];
+  const crumbs = [SITE.NAME, competition?.name || notFoundCompetition.name, currentProblem.title];
 
   return (
     <main className={style}>
       <ContestBreadCrumb crumbs={crumbs} />
       <section>
-        <span className={problemTitleStyle}>{problemList[currentProblemId].title}</span>
+        <span className={problemTitleStyle}>{currentProblem.title}</span>
       </section>
       <section className={rowListStyle}>
-        <ProblemViewer content={problemList[currentProblemId].content}></ProblemViewer>
+        <ProblemViewer content={currentProblem.content}></ProblemViewer>
         <div className={colListStyle}>
-          <Editor
-            code={problemList[currentProblemId].solutionCode}
-            onChangeCode={handleChangeCode}
-          ></Editor>
+          <Editor code={currentProblem.solutionCode} onChangeCode={handleChangeCode}></Editor>
           <SimulationInputList
             inputList={simulationInputs}
             onChangeInput={handleChangeInput}

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -140,7 +140,10 @@ export default function ContestPage() {
       <section className={rowListStyle}>
         <ProblemViewer content={problemList[currentProblemId].content}></ProblemViewer>
         <div className={colListStyle}>
-          <Editor code={code} onChangeCode={handleChangeCode}></Editor>
+          <Editor
+            code={problemList[currentProblemId].solutionCode}
+            onChangeCode={handleChangeCode}
+          ></Editor>
           <SimulationInputList
             inputList={simulationInputs}
             onChangeInput={handleChangeInput}

--- a/frontend/src/pages/ProblemPage.tsx
+++ b/frontend/src/pages/ProblemPage.tsx
@@ -18,27 +18,30 @@ interface Problem {
 
 const PROBLEM_API_ENDPOINT = 'http://101.101.208.240:3000/problems/';
 
+const fetchProblem = async (
+  problemId: number,
+  setProblem: (problem: Problem | null) => void,
+  setLoading: (loading: boolean) => void,
+) => {
+  try {
+    const response = await axios.get<Problem>(`${PROBLEM_API_ENDPOINT}${problemId}`);
+    const data = response.data;
+    setProblem(data);
+  } catch (error) {
+    console.error('Error fetching problem:', (error as Error).message);
+  } finally {
+    setLoading(false);
+  }
+};
+
 function ProblemPage() {
   const { id } = useParams<{ id: string }>();
-  const problemId = id ? parseInt(id, 10) : null;
+  const problemId = id ? parseInt(id, 10) : -1;
   const [problem, setProblem] = useState<Problem | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const fetchProblem = async () => {
-      try {
-        const response = await axios.get<Problem>(`${PROBLEM_API_ENDPOINT}${problemId}`);
-        const data = response.data;
-
-        setProblem(data);
-      } catch (error) {
-        console.error('Error fetching problem:', (error as Error).message);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchProblem();
+    fetchProblem(problemId, setProblem, setLoading);
   }, [problemId]);
 
   if (loading) {

--- a/frontend/src/pages/ProblemPage.tsx
+++ b/frontend/src/pages/ProblemPage.tsx
@@ -1,31 +1,57 @@
 import { css } from '@style/css';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import ProblemViewer from '@/components/Problem/ProblemViewer';
-import mockData from '@/mockData.json';
 
-const notFoundProblem = {
-  title: 'Problem Not Found',
-  timeLimit: 0,
-  memoryLimit: 0,
-  content: 'The requested problem could not be found.',
-  solutionCode: '',
-  testcases: [],
-  createdAt: new Date().toISOString(),
-};
+import axios from 'axios';
 
-const INITIAL_PROBLEM_ID = 6;
+interface Problem {
+  id: number;
+  title: string;
+  timeLimit: number;
+  memoryLimit: number;
+  content: string;
+  createdAt: string;
+}
+
+const PROBLEM_API_ENDPOINT = 'http://101.101.208.240:3000/problems/';
 
 function ProblemPage() {
-  const [currentProblemId] = useState(INITIAL_PROBLEM_ID);
-  const targetProblem =
-    mockData.problems.find((problem) => problem.id === currentProblemId) || notFoundProblem;
+  const { id } = useParams<{ id: string }>();
+  const problemId = id ? parseInt(id, 10) : null;
+  const [problem, setProblem] = useState<Problem | null>(null);
+  const [loading, setLoading] = useState(true);
 
+  useEffect(() => {
+    const fetchProblem = async () => {
+      try {
+        const response = await axios.get<Problem>(`${PROBLEM_API_ENDPOINT}${problemId}`);
+        const data = response.data;
+
+        setProblem(data);
+      } catch (error) {
+        console.error('Error fetching problem:', (error as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProblem();
+  }, [problemId]);
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  if (!problem) {
+    return <p>Error loading problem data</p>;
+  }
   return (
     <main className={style}>
-      <span className={problemTitleStyle}>{targetProblem.title}</span>
-      <ProblemViewer content={targetProblem.content} />
+      <span className={problemTitleStyle}>{problem.title}</span>
+      <ProblemViewer content={problem.content} />
     </main>
   );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -15,7 +15,7 @@ const router = createBrowserRouter([
         element: <ContestPage />,
       },
       {
-        path: '/problem/:id', // TODO: api 연동 후 수정
+        path: '/problem/:id',
         element: <ProblemPage />,
       },
     ],

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,6 +12,7 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
+        path: '/contest/:id',
         element: <ContestPage />,
       },
       {


### PR DESCRIPTION
## 한 일
- 대회 화면 페이지와 문제 보기 페이지에서 실제 api를 받아 대회와 문제에 대한 정보를 처리하도록 코드를 작성하였습니다.
- 대회 화면 페이지에 대해 라우터를 수정해서 대회 id에 따라 화면을 출력하도록 코드를 수정하였습니다.

### TODO
- 대회 정보 api 안에 해당 대회에 어떠한 정보가 들어있는지에 대한 응답 데이터가 없어서, BE에서 이를 처리해주면 코드를 수정해야 합니다.


### 대회 화면 ('/contest/:id')
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/99582579-42b3-489a-8753-4b990075f89a)

### 문제 보기 화면('/problem/:id')
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/67fb1a75-c57e-4dc0-aa31-9893d72276d9)


### 리뷰 질문
- 현재 ContestPage안에서 useEffect를 두 개로 나눠서 사용하고 있는데, 이렇게 하는 게 좋은 방법인지 궁금합니다!