### PR TITLE
[#90] 대회별 문제 목록 조회 api 구현

### DIFF
--- a/be/algo-with-me-api/src/app.module.ts
+++ b/be/algo-with-me-api/src/app.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from './auth/auth.module';
 import { CompetitionModule } from './competition/competition.module';
+import { CompetitionProblem } from './competition/entities/competition.problem.entity';
 import { Problem } from './competition/entities/problem.entity';
 import { Submission } from './competition/entities/submission.entity';
 import { User } from './user/entities/user.entity';
@@ -26,7 +27,8 @@ import { Competition } from '@src/competition/entities/competition.entity';
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       synchronize: true,
-      entities: [Problem, Submission, Competition, User],
+      entities: [Problem, Submission, Competition, User, CompetitionProblem],
+      logging: true,
     }),
     BullModule.forRoot({
       redis: {

--- a/be/algo-with-me-api/src/competition/competition.module.ts
+++ b/be/algo-with-me-api/src/competition/competition.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CompetitionController } from './controllers/competition.controller';
 import { ProblemController } from './controllers/problem.controller';
+import { CompetitionProblem } from './entities/competition.problem.entity';
 import { Problem } from './entities/problem.entity';
 import { Submission } from './entities/submission.entity';
 import { CompetitionGateWay } from './gateways/competition.gateway';
@@ -15,7 +16,7 @@ import { Competition } from '@src/competition/entities/competition.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Problem, Submission, Competition]),
+    TypeOrmModule.forFeature([Problem, Submission, Competition, CompetitionProblem]),
     BullModule.registerQueue({
       name: process.env.REDIS_MESSAGE_QUEUE_NAME,
     }),

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -15,14 +15,14 @@ import { CompetitionResponseDto } from '@src/competition/dto/competition.respons
 export class CompetitionController {
   constructor(private readonly competitionService: CompetitionService) {}
 
-  @Get('/:id')
+  @Get('/:competitionId')
   @ApiOperation({
     summary: '대회 정보 조회',
     description: 'URL의 파라미터(`/:id`)로 주어진 대회 id에 해당하는 대회 정보를 조회한다.',
   })
   @ApiResponse({ type: CompetitionResponseDto })
-  findOne(@Param('id') id: number) {
-    return this.competitionService.findOne(id);
+  findOne(@Param('competitionId') competitionId: number) {
+    return this.competitionService.findOne(competitionId);
   }
 
   @Post('/')
@@ -36,15 +36,18 @@ export class CompetitionController {
     return this.competitionService.create(createCompetitionDto);
   }
 
-  @Put('/:id')
+  @Put('/:competitionId')
   @ApiOperation({
     summary: '대회 정보 수정',
     description: `URL의 파라미터(\`/:id\`)로 주어진 대회 id에 해당하는 대회 정보를 수정한다. request JSON 중 **수정하기를 원하는 것만** key: value 형식으로 요청한다.`,
   })
   @ApiResponse({ type: Boolean })
   @UsePipes(new ValidationPipe({ transform: true }))
-  update(@Param('id') id: number, @Body() updateCompetitionDto: UpdateCompetitionDto) {
-    return this.competitionService.update(id, updateCompetitionDto);
+  update(
+    @Param('competitionId') competitionId: number,
+    @Body() updateCompetitionDto: UpdateCompetitionDto,
+  ) {
+    return this.competitionService.update(competitionId, updateCompetitionDto);
   }
 
   @Get('/:competitionId/problems')
@@ -54,11 +57,11 @@ export class CompetitionController {
     return this.competitionService.findCompetitionProblemList(competitionId);
   }
 
-  @Get('problems/:id')
+  @Get('problems/:problemId')
   @ApiOperation({ summary: '대회 문제 상세 조회' })
   @ApiResponse({ type: CompetitionProblemResponseDto })
-  findOneProblem(@Param('id') id: number) {
-    return this.competitionService.findOneProblem(id);
+  findOneProblem(@Param('problemId') problemId: number) {
+    return this.competitionService.findOneProblem(problemId);
   }
 
   @Post('scores')

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { CompetitionProblemResponseDto } from '../dto/competition.problem.response.dto';
 import { CreateCompetitionDto } from '../dto/create-competition.dto';
+import { ProblemSimpleResponseDto } from '../dto/problem.simple.response.dto';
 import { ScoreResultDto } from '../dto/score-result.dto';
 import { UpdateCompetitionDto } from '../dto/update-competition.dto';
 import { CompetitionService } from '../services/competition.service';
@@ -44,6 +45,13 @@ export class CompetitionController {
   @UsePipes(new ValidationPipe({ transform: true }))
   update(@Param('id') id: number, @Body() updateCompetitionDto: UpdateCompetitionDto) {
     return this.competitionService.update(id, updateCompetitionDto);
+  }
+
+  @Get('/:competitionId/problems')
+  @ApiOperation({ summary: '대회별 문제 목록 조회' })
+  @ApiResponse({ type: ProblemSimpleResponseDto, isArray: true })
+  findCompetitionProblem(@Param('competitionId') competitionId: number) {
+    return this.competitionService.findCompetitionProblemList(competitionId);
   }
 
   @Get('problems/:id')

--- a/be/algo-with-me-api/src/competition/controllers/problem.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/problem.controller.ts
@@ -11,8 +11,8 @@ import {
 import { ApiCreatedResponse, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { CreateProblemDto } from '../dto/create-problem.dto';
-import { ProblemListResponseDto } from '../dto/problem.list.response.dto';
 import { ProblemResponseDto } from '../dto/problem.response.dto';
+import { ProblemSimpleResponseDto } from '../dto/problem.simple.response.dto';
 import { Problem } from '../entities/problem.entity';
 import { ProblemService } from '../services/problem.service';
 
@@ -31,7 +31,7 @@ export class ProblemController {
 
   @Get()
   @ApiOperation({ summary: '문제 전체 조회', description: '문제 목록을 조회한다.' })
-  @ApiResponse({ type: ProblemListResponseDto, isArray: true })
+  @ApiResponse({ type: ProblemSimpleResponseDto, isArray: true })
   findAll() {
     return this.problemService.findAll();
   }

--- a/be/algo-with-me-api/src/competition/dto/problem.simple.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/problem.simple.response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class ProblemListResponseDto {
+export class ProblemSimpleResponseDto {
   constructor(id: number, title: string) {
     this.id = id;
     this.title = title;

--- a/be/algo-with-me-api/src/competition/entities/competition.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.entity.ts
@@ -3,14 +3,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  JoinTable,
-  ManyToMany,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 
-import { Problem } from './problem.entity';
+import { CompetitionProblem } from './competition.problem.entity';
 import { Submission } from './submission.entity';
 
 @Entity()
@@ -43,14 +41,9 @@ export class Competition {
   @OneToMany(() => Submission, (submission) => submission.competition)
   submissions: Submission[];
 
-  @ApiProperty({ description: '문제(problem) 테이블과 다대다 관계' })
-  @ManyToMany(() => Problem, (problem) => problem.competitions)
-  @JoinTable({
-    name: 'CompetitionProblem',
-    joinColumn: { name: 'competitionId', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'problemId', referencedColumnName: 'id' },
-  })
-  problems: Problem[];
+  @ApiProperty({ description: '대회문제(competitionProblem) 테이블과 일대다 관계' })
+  @OneToMany(() => CompetitionProblem, (competitionProblem) => competitionProblem.competition)
+  competitionProblems: CompetitionProblem[];
 
   @ApiProperty({ description: '레코드 생성 일시' })
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Competition } from './competition.entity';
+import { Problem } from './problem.entity';
+
+@Entity()
+export class CompetitionProblem {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ description: 'id' })
+  id: number;
+
+  @ApiProperty({ description: '대회(competition) 테이블과 다대일 관계' })
+  @ManyToOne(() => CompetitionProblem, (competitionProblem) => competitionProblem.competition)
+  competition: Competition;
+
+  @ApiProperty({ description: '문제(problem) 테이블과 다대일 관계' })
+  @ManyToOne(() => CompetitionProblem, (CompetitionProblem) => CompetitionProblem.problem)
+  problem: Problem;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
@@ -11,11 +11,11 @@ export class CompetitionProblem {
   id: number;
 
   @ApiProperty({ description: '대회(competition) 테이블과 다대일 관계' })
-  @ManyToOne(() => CompetitionProblem, (competitionProblem) => competitionProblem.competition)
+  @ManyToOne(() => Competition, (competition) => competition.competitionProblems)
   competition: Competition;
 
   @ApiProperty({ description: '문제(problem) 테이블과 다대일 관계' })
-  @ManyToOne(() => CompetitionProblem, (CompetitionProblem) => CompetitionProblem.problem)
+  @ManyToOne(() => Problem, (problem) => problem.competitionProblems)
   problem: Problem;
 
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/entities/problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/problem.entity.ts
@@ -3,14 +3,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  ManyToMany,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
-  JoinTable,
 } from 'typeorm';
 
-import { Competition } from './competition.entity';
+import { CompetitionProblem } from './competition.problem.entity';
 import { Submission } from './submission.entity';
 
 @Entity()
@@ -47,14 +45,9 @@ export class Problem {
   @OneToMany(() => Submission, (submission) => submission.problem)
   submissions: Submission[];
 
-  @ApiProperty()
-  @ManyToMany(() => Competition, (competition) => competition.problems)
-  @JoinTable({
-    name: 'CompetitionProblem',
-    joinColumn: { name: 'problemId', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'competitionId', referencedColumnName: 'id' },
-  })
-  competitions: Competition[];
+  @ApiProperty({ description: '대회문제(competitionProblem) 테이블과 일대다 관계' })
+  @OneToMany(() => CompetitionProblem, (competitionProblem) => competitionProblem.problem)
+  competitionProblems: CompetitionProblem[];
 
   @ApiProperty()
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/services/problem.service.ts
+++ b/be/algo-with-me-api/src/competition/services/problem.service.ts
@@ -6,8 +6,8 @@ import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 
 import { CreateProblemDto } from '../dto/create-problem.dto';
-import { ProblemListResponseDto } from '../dto/problem.list.response.dto';
 import { ProblemResponseDto } from '../dto/problem.response.dto';
+import { ProblemSimpleResponseDto } from '../dto/problem.simple.response.dto';
 import { Problem } from '../entities/problem.entity';
 
 @Injectable()
@@ -24,7 +24,7 @@ export class ProblemService {
   async findAll() {
     const problems = await this.problemRepository.find();
     return problems.map((problem: Problem) => {
-      return new ProblemListResponseDto(problem.id, problem.title);
+      return new ProblemSimpleResponseDto(problem.id, problem.title);
     });
   }
 


### PR DESCRIPTION
resolved #90 
- 대회별 문제 목록 조회 api 구현
- 다대다 데코레이터를 없애고 중간 테이블 엔티티를 구현하였습니다.
    - join을 줄이고 select 되는 컬럼들을 줄여보려고 했습니다. 결과적으로 두번의 조인이 발생합니다.
- typeorm 쿼리 로그를 출력하도록 수정했습니다.
- 그냥 id를 사용하던 것을 어떤 id인지 구분하기 쉽게 변수명을 수정했습니다.


## 참고
https://www.notion.so/api-d479ad4a28df4e72b98b4952a1a3fbac?pvs=4