### PR TITLE
[#94] 대회 조회/생성 api 수정

### DIFF
--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -15,10 +15,20 @@ import { CompetitionResponseDto } from '@src/competition/dto/competition.respons
 export class CompetitionController {
   constructor(private readonly competitionService: CompetitionService) {}
 
+  @Get('/')
+  @ApiOperation({
+    summary: '대회 정보 전체 조회',
+    description: '모든 대회 정보를 조회한다.',
+  })
+  @ApiResponse({ type: CompetitionResponseDto })
+  findAll() {
+    return this.competitionService.findAll();
+  }
+
   @Get('/:competitionId')
   @ApiOperation({
-    summary: '대회 정보 조회',
-    description: 'URL의 파라미터(`/:id`)로 주어진 대회 id에 해당하는 대회 정보를 조회한다.',
+    summary: '대회 세부 정보 조회',
+    description: 'URL의 파라미터(`/:id`)로 주어진 대회 id에 해당하는 대회 세부 정보를 조회한다.',
   })
   @ApiResponse({ type: CompetitionResponseDto })
   findOne(@Param('competitionId') competitionId: number) {

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -38,7 +38,7 @@ export class CompetitionController {
   @Post('/')
   @ApiOperation({
     summary: '대회 생성',
-    description: `주어진 대회 관련 정보를 이용해 대회를 생성한다.`,
+    description: `주어진 대회 관련 정보를 이용해 대회를 생성한다. 과도한 DB 접근을 막기 위해, 하나의 대회에서 30개가 넘는 문제를 출제할 수 없도록 정책 상 제한한다.`,
   })
   @ApiResponse({ type: CompetitionResponseDto })
   @UsePipes(new ValidationPipe({ transform: true }))

--- a/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 
-import { Competition } from '@src/competition/entities/competition.entity';
-
 export class CompetitionResponseDto {
   constructor(
     id: number,
@@ -11,6 +9,7 @@ export class CompetitionResponseDto {
     maxParticipants: number,
     startsAt: string,
     endsAt: string,
+    problems: number[],
     createdAt: string,
     updatedAt: string,
   ) {
@@ -20,6 +19,7 @@ export class CompetitionResponseDto {
     this.maxParticipants = maxParticipants;
     this.startsAt = startsAt;
     this.endsAt = endsAt;
+    this.problemIds = problems;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }
@@ -48,6 +48,10 @@ export class CompetitionResponseDto {
   @IsNotEmpty()
   endsAt: string;
 
+  @ApiProperty({ description: '대회에 사용되는 문제 id 리스트' })
+  @IsNotEmpty()
+  problemIds: number[];
+
   @ApiProperty({ description: '레코드 생성 일시 (ISO string)' })
   @IsNotEmpty()
   createdAt: string;
@@ -56,16 +60,27 @@ export class CompetitionResponseDto {
   @IsNotEmpty()
   updatedAt: string;
 
-  static from(competition: Competition) {
+  static from(args: {
+    id: number;
+    name: string;
+    detail: string;
+    maxParticipants: number;
+    startsAt: Date;
+    endsAt: Date;
+    problemIds: number[];
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
     return new CompetitionResponseDto(
-      competition.id,
-      competition.name,
-      competition.detail,
-      competition.maxParticipants,
-      competition.startsAt.toISOString(),
-      competition.endsAt.toISOString(),
-      competition.createdAt.toISOString(),
-      competition.updatedAt.toISOString(),
+      args.id,
+      args.name,
+      args.detail,
+      args.maxParticipants,
+      args.startsAt.toISOString(),
+      args.endsAt.toISOString(),
+      args.problemIds,
+      args.createdAt.toISOString(),
+      args.updatedAt.toISOString(),
     );
   }
 }

--- a/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 
+import { Competition } from '@src/competition/entities/competition.entity';
+
 export class CompetitionResponseDto {
   constructor(
     id: number,
@@ -53,4 +55,17 @@ export class CompetitionResponseDto {
   @ApiProperty({ description: '레코드 수정 일시 (ISO string)' })
   @IsNotEmpty()
   updatedAt: string;
+
+  static from(competition: Competition) {
+    return new CompetitionResponseDto(
+      competition.id,
+      competition.name,
+      competition.detail,
+      competition.maxParticipants,
+      competition.startsAt.toISOString(),
+      competition.endsAt.toISOString(),
+      competition.createdAt.toISOString(),
+      competition.updatedAt.toISOString(),
+    );
+  }
 }

--- a/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.response.dto.ts
@@ -9,7 +9,6 @@ export class CompetitionResponseDto {
     maxParticipants: number,
     startsAt: string,
     endsAt: string,
-    problems: number[],
     createdAt: string,
     updatedAt: string,
   ) {
@@ -19,7 +18,6 @@ export class CompetitionResponseDto {
     this.maxParticipants = maxParticipants;
     this.startsAt = startsAt;
     this.endsAt = endsAt;
-    this.problemIds = problems;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }
@@ -67,7 +65,6 @@ export class CompetitionResponseDto {
     maxParticipants: number;
     startsAt: Date;
     endsAt: Date;
-    problemIds: number[];
     createdAt: Date;
     updatedAt: Date;
   }) {
@@ -78,7 +75,6 @@ export class CompetitionResponseDto {
       args.maxParticipants,
       args.startsAt.toISOString(),
       args.endsAt.toISOString(),
-      args.problemIds,
       args.createdAt.toISOString(),
       args.updatedAt.toISOString(),
     );

--- a/be/algo-with-me-api/src/competition/dto/competition.simple-response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.simple-response.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+import { Competition } from '@src/competition/entities/competition.entity';
+
+export class CompetitionSimpleResponseDto {
+  constructor(
+    id: number,
+    name: string,
+    detail: string,
+    maxParticipants: number,
+    startsAt: string,
+    endsAt: string,
+    createdAt: string,
+    updatedAt: string,
+  ) {
+    this.id = id;
+    this.name = name;
+    this.detail = detail;
+    this.maxParticipants = maxParticipants;
+    this.startsAt = startsAt;
+    this.endsAt = endsAt;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  @ApiProperty({ description: '대회 id' })
+  @IsNotEmpty()
+  id: number;
+
+  @ApiProperty({ description: '대회 이름' })
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: '대회에 대한 설명글' })
+  @IsNotEmpty()
+  detail: string;
+
+  @ApiProperty({ description: '대회에 참여 가능한 최대 인원' })
+  @IsNotEmpty()
+  maxParticipants: number;
+
+  @ApiProperty({ description: '대회 시작 일시 (ISO string)' })
+  @IsNotEmpty()
+  startsAt: string;
+
+  @ApiProperty({ description: '대회 종료 일시 (ISO string)' })
+  @IsNotEmpty()
+  endsAt: string;
+
+  @ApiProperty({ description: '레코드 생성 일시 (ISO string)' })
+  @IsNotEmpty()
+  createdAt: string;
+
+  @ApiProperty({ description: '레코드 수정 일시 (ISO string)' })
+  @IsNotEmpty()
+  updatedAt: string;
+}

--- a/be/algo-with-me-api/src/competition/dto/competition.simple-response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.simple-response.dto.ts
@@ -55,4 +55,17 @@ export class CompetitionSimpleResponseDto {
   @ApiProperty({ description: '레코드 수정 일시 (ISO string)' })
   @IsNotEmpty()
   updatedAt: string;
+
+  static from(competition: Competition) {
+    return new CompetitionSimpleResponseDto(
+      competition.id,
+      competition.name,
+      competition.detail,
+      competition.maxParticipants,
+      competition.startsAt.toISOString(),
+      competition.endsAt.toISOString(),
+      competition.createdAt.toISOString(),
+      competition.updatedAt.toISOString(),
+    );
+  }
 }

--- a/be/algo-with-me-api/src/competition/dto/create-competition.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/create-competition.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 
-import { Competition } from '@src/competition/entities/competition.entity';
-
 export class CreateCompetitionDto {
   constructor(
     name: string,

--- a/be/algo-with-me-api/src/competition/dto/create-competition.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/create-competition.dto.ts
@@ -10,12 +10,14 @@ export class CreateCompetitionDto {
     maxParticipants: number,
     startsAt: string,
     endsAt: string,
+    problemIds: number[],
   ) {
     this.name = name;
     this.detail = detail;
     this.maxParticipants = maxParticipants;
-    this.startsAt = startsAt;
+    this.problemIds = problemIds;
     this.endsAt = endsAt;
+    this.startsAt = startsAt;
   }
 
   @ApiProperty({ description: '대회 이름' })
@@ -38,13 +40,7 @@ export class CreateCompetitionDto {
   @IsNotEmpty()
   endsAt: string;
 
-  toEntity(): Competition {
-    const competition = new Competition();
-    competition.name = this.name;
-    competition.detail = this.detail;
-    competition.maxParticipants = this.maxParticipants;
-    competition.startsAt = new Date(this.startsAt);
-    competition.endsAt = new Date(this.endsAt);
-    return competition;
-  }
+  @ApiProperty({ description: '대회에 사용되는 문제 id 리스트' })
+  @IsNotEmpty()
+  problemIds: number[];
 }

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -1,16 +1,9 @@
 import { InjectQueue } from '@nestjs/bull';
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Queue } from 'bull';
 import { Server } from 'socket.io';
-import {
-  DataSource,
-  EntityManager,
-  getConnection,
-  getConnectionManager,
-  getManager,
-  Repository,
-} from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
 import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -37,16 +37,7 @@ export class CompetitionService {
   async findAll() {
     const competitionList = await this.competitionRepository.find();
     return competitionList.map((competition) => {
-      return new CompetitionSimpleResponseDto(
-        competition.id,
-        competition.name,
-        competition.detail,
-        competition.maxParticipants,
-        competition.startsAt.toISOString(),
-        competition.endsAt.toISOString(),
-        competition.createdAt.toISOString(),
-        competition.updatedAt.toISOString(),
-      );
+      return CompetitionSimpleResponseDto.from(competition);
     });
   }
 
@@ -54,30 +45,12 @@ export class CompetitionService {
     const result = await this.competitionRepository.findOneBy({ id });
     if (!result)
       throw new NotFoundException(`대회 id ${id}에 해당하는 대회 정보를 찾을 수 없습니다`);
-    return new CompetitionResponseDto(
-      result.id,
-      result.name,
-      result.detail,
-      result.maxParticipants,
-      result.startsAt.toISOString(),
-      result.endsAt.toISOString(),
-      result.createdAt.toISOString(),
-      result.updatedAt.toISOString(),
-    );
+    return CompetitionResponseDto.from(result);
   }
 
   async create(createCompetitionDto: CreateCompetitionDto) {
     const result = await this.competitionRepository.save(createCompetitionDto.toEntity());
-    return new CompetitionResponseDto(
-      result.id,
-      result.name,
-      result.detail,
-      result.maxParticipants,
-      result.startsAt.toISOString(),
-      result.endsAt.toISOString(),
-      result.createdAt.toISOString(),
-      result.updatedAt.toISOString(),
-    );
+    return CompetitionResponseDto.from(result);
   }
 
   async update(id: number, updateCompetitionDto: UpdateCompetitionDto) {

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -44,27 +44,11 @@ export class CompetitionService {
 
   async findOne(competitionId: number) {
     const competition = await this.competitionRepository.findOneBy({ id: competitionId });
-    const problems = await this.competitionProblemRepository.find({
-      select: {
-        problem: { id: true },
-      },
-      where: {
-        competition: { id: competitionId },
-      },
-      relations: {
-        problem: true,
-      },
-    });
-    const problemIds = problems.map((element) => element.problem.id);
     if (!competition)
       throw new NotFoundException(
         `대회 id ${competitionId}에 해당하는 대회 정보를 찾을 수 없습니다`,
       );
-    if (!problems)
-      throw new NotFoundException(
-        `대회 id ${competitionId}에 해당하는 문제 리스트를 찾는 데에 실패했습니다`,
-      );
-    return CompetitionResponseDto.from({ ...competition, problemIds });
+    return CompetitionResponseDto.from(competition);
   }
 
   async create(createCompetitionDto: CreateCompetitionDto) {

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -17,6 +17,7 @@ import { Problem } from '../entities/problem.entity';
 import { Submission } from '../entities/submission.entity';
 
 import { CompetitionResponseDto } from '@src/competition/dto/competition.response.dto';
+import { CompetitionSimpleResponseDto } from '@src/competition/dto/competition.simple-response.dto';
 import { CreateCompetitionDto } from '@src/competition/dto/create-competition.dto';
 import { UpdateCompetitionDto } from '@src/competition/dto/update-competition.dto';
 import { Competition } from '@src/competition/entities/competition.entity';
@@ -32,6 +33,22 @@ export class CompetitionService {
     private readonly competitionProblemRepository: Repository<CompetitionProblem>,
     @InjectQueue(process.env.REDIS_MESSAGE_QUEUE_NAME) private submissionQueue: Queue,
   ) {}
+
+  async findAll() {
+    const competitionList = await this.competitionRepository.find();
+    return competitionList.map((competition) => {
+      return new CompetitionSimpleResponseDto(
+        competition.id,
+        competition.name,
+        competition.detail,
+        competition.maxParticipants,
+        competition.startsAt.toISOString(),
+        competition.endsAt.toISOString(),
+        competition.createdAt.toISOString(),
+        competition.updatedAt.toISOString(),
+      );
+    });
+  }
 
   async findOne(id: number) {
     const result = await this.competitionRepository.findOneBy({ id });

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -1,5 +1,5 @@
 import { InjectQueue } from '@nestjs/bull';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Queue } from 'bull';
 import { Server } from 'socket.io';
@@ -52,6 +52,11 @@ export class CompetitionService {
   }
 
   async create(createCompetitionDto: CreateCompetitionDto) {
+    if (createCompetitionDto.problemIds.length > 30) {
+      throw new BadRequestException(
+        `정책 상 하나의 대회에서는 30개가 넘는 문제를 출제할 수 없습니다. (${createCompetitionDto.problemIds.length}개를 출제함)`,
+      );
+    }
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
 


### PR DESCRIPTION
- 대회 전체 조회 API 구현했습니다.
- 대회 생성 API에서, 대회에 사용되는 문제 리스트를 입력으로 받도록 했습니다. (problems: number[])

바로 배포할 계획입니다.