### PR TITLE
[#99] 로그인 페이지 구현

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,10 @@
-<!doctype html>
-<html lang="en">
+<!DOCTYPE html>
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Algo With Me</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -3,7 +3,7 @@ import { css } from '@style/css';
 const GITHUB_AUTH_URL = 'http://101.101.208.240:3000/auths/github';
 
 export default function Login() {
-  const handleLogIn = async () => {
+  const handleLogin = () => {
     try {
       window.location.href = GITHUB_AUTH_URL;
     } catch (e) {
@@ -15,7 +15,7 @@ export default function Login() {
   return (
     <section className={loginWrapperStyle}>
       <header className={loginHeaderStyle}>Algo With Me</header>
-      <button onClick={handleLogIn}>Github으로 로그인</button>
+      <button onClick={handleLogin}>Github으로 로그인</button>
     </section>
   );
 }

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -1,0 +1,40 @@
+import { css } from '@style/css';
+
+const GITHUB_AUTH_URL = 'http://101.101.208.240:3000/auths/github';
+
+export default function Login() {
+  const handleLogIn = async () => {
+    try {
+      window.location.href = GITHUB_AUTH_URL;
+    } catch (e) {
+      const error = e as Error;
+      console.error(error.message);
+    }
+  };
+
+  return (
+    <section className={loginWrapperStyle}>
+      <header className={loginHeaderStyle}>Algo With Me</header>
+      <button onClick={handleLogIn}>Github으로 로그인</button>
+    </section>
+  );
+}
+
+const loginWrapperStyle = css({
+  border: '1px solid white',
+  borderRadius: '10px',
+  width: '100%',
+  height: '100%',
+  maxWidth: '500px',
+  maxHeight: '200px',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+});
+
+const loginHeaderStyle = css({
+  fontSize: '3rem',
+  fontWeight: 'bold',
+  textAlign: 'center',
+  padding: '1rem',
+});

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -1,21 +1,14 @@
 import { css } from '@style/css';
 
-const GITHUB_AUTH_URL = 'http://101.101.208.240:3000/auths/github';
+interface Props {
+  onClickLogin: () => void;
+}
 
-export default function Login() {
-  const handleLogin = () => {
-    try {
-      window.location.href = GITHUB_AUTH_URL;
-    } catch (e) {
-      const error = e as Error;
-      console.error(error.message);
-    }
-  };
-
+export default function Login({ onClickLogin }: Props) {
   return (
     <section className={loginWrapperStyle}>
       <header className={loginHeaderStyle}>Algo With Me</header>
-      <button onClick={handleLogin}>Github으로 로그인</button>
+      <button onClick={onClickLogin}>Github으로 로그인</button>
     </section>
   );
 }

--- a/frontend/src/components/Problem/Markdown.tsx
+++ b/frontend/src/components/Problem/Markdown.tsx
@@ -3,41 +3,50 @@ import { css } from '@style/css';
 import { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 
-import type { Components } from 'hast-util-to-jsx-runtime/lib/components';
 import remarkGfm from 'remark-gfm';
+
+interface Components {
+  table: (props: TableProps) => JSX.Element;
+  th: (props: ThProps) => JSX.Element;
+  td: (props: TdProps) => JSX.Element;
+  code: (props: CodeProps) => JSX.Element;
+  ul: (props: UlProps) => JSX.Element;
+  ol: (props: OlProps) => JSX.Element;
+  li: (props: LiProps) => JSX.Element;
+}
 
 interface Props {
   markdownContent: string;
 }
 
 interface TableProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface ThProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface TdProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface CodeProps {
   inline?: boolean;
   className?: string;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface UlProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface OlProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface LiProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export default function Markdown(props: Props) {

--- a/frontend/src/components/submissionResult/ResultList.tsx
+++ b/frontend/src/components/submissionResult/ResultList.tsx
@@ -3,6 +3,7 @@ import { css } from '@style/css';
 import { useCallback, useEffect, useState } from 'react';
 
 import ResultInfoWrapper from './ResultInfoWrapper';
+import type { SubmitResult } from './types';
 
 interface TestcaseLoadInfo {
   [index: string]: boolean;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,17 @@
+import Login from '@/components/Login';
+
+const GITHUB_AUTH_URL = 'http://101.101.208.240:3000/auths/github';
+
+export default function LoginPage() {
+  // 넘겨주는 함수는 handle, 함수를 넘길 때의 프로펄티 네임은 on
+  const handleLogin = () => {
+    try {
+      window.location.href = GITHUB_AUTH_URL;
+    } catch (e) {
+      const error = e as Error;
+      console.error(error.message);
+    }
+  };
+
+  return <Login onClickLogin={handleLogin} />;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 
-import Login from '@/components/Login';
 import ContestPage from '@/pages/ContestPage';
+import LoginPage from '@/pages/LoginPage';
 import ProblemPage from '@/pages/ProblemPage';
 
 import App from './App';
@@ -21,7 +21,7 @@ const router = createBrowserRouter(
           path: '/problem/:id',
           element: <ProblemPage />,
         },
-        { path: '/login', element: <Login /> },
+        { path: '/login', element: <LoginPage /> },
       ],
     },
   ],

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,26 +1,31 @@
 import { createBrowserRouter } from 'react-router-dom';
 
+import Login from '@/components/Login';
 import ContestPage from '@/pages/ContestPage';
 import ProblemPage from '@/pages/ProblemPage';
 
 import App from './App';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <App />,
-    children: [
-      {
-        index: true,
-        path: '/contest/:id',
-        element: <ContestPage />,
-      },
-      {
-        path: '/problem/:id',
-        element: <ProblemPage />,
-      },
-    ],
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <App />,
+      children: [
+        {
+          index: true,
+          path: '/contest/:id',
+          element: <ContestPage />,
+        },
+        {
+          path: '/problem/:id',
+          element: <ProblemPage />,
+        },
+        { path: '/login', element: <Login /> },
+      ],
+    },
+  ],
+  { basename: process.env.NODE_ENV === 'production' ? '/web12-algo-with-me' : '' },
+);
 
 export default router;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,10 +3,7 @@ import path from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  server: {
-    open: process.env.NODE_ENV === 'development' ? '' : 'dist/index.html',
-  },
-  base: '',
+  base: './',
   resolve: {
     alias: [
       {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   server: {
-    open: 'frontend/dist/index.html',
+    open: process.env.NODE_ENV === 'development' ? '' : 'dist/index.html',
   },
   base: '',
   resolve: {


### PR DESCRIPTION
### 한 일

- fe-dev를 rebase하는 과정에서 타인의 코드가 섞이는 문제가 발생해서 최신 fe-dev에서 새로운 브랜치를 하나 팠습니다. 
- 이전 브랜치 
https://github.com/boostcampwm2023/web12-algo-with-me/compare/fe-dev...99-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%ED%8E%98%EC%9D%B4%EC%A7%80-%EA%B5%AC%ED%98%84

- 로그인 페이지 구현
- 배포위한 vite 설정 추가
- 라우팅 작업
- build 시에 발생하는 타입에러 수정

### ToDo 

- accessToken 저장 로직은 [#69]의 브랜치 코드 그대로 main page가 생기면 추가하겠습니다.
- 위의 작업은 commons header 작업을 할 때 수행됩니다.
