### PR TITLE
[#55] 대회 참여 api 구현, swagger, 에러핸들링

### DIFF
--- a/be/algo-with-me-api/src/app.module.ts
+++ b/be/algo-with-me-api/src/app.module.ts
@@ -5,8 +5,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from './auth/auth.module';
 import { CompetitionModule } from './competition/competition.module';
-import { CompetitionProblem } from './competition/entities/competition.problem.entity';
 import { CompetitionParticipant } from './competition/entities/competition.participant.entity';
+import { CompetitionProblem } from './competition/entities/competition.problem.entity';
 import { Problem } from './competition/entities/problem.entity';
 import { Submission } from './competition/entities/submission.entity';
 import { User } from './user/entities/user.entity';

--- a/be/algo-with-me-api/src/app.module.ts
+++ b/be/algo-with-me-api/src/app.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { CompetitionModule } from './competition/competition.module';
 import { CompetitionProblem } from './competition/entities/competition.problem.entity';
+import { CompetitionParticipant } from './competition/entities/competition.participant.entity';
 import { Problem } from './competition/entities/problem.entity';
 import { Submission } from './competition/entities/submission.entity';
 import { User } from './user/entities/user.entity';
@@ -27,7 +28,14 @@ import { Competition } from '@src/competition/entities/competition.entity';
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       synchronize: true,
-      entities: [Problem, Submission, Competition, User, CompetitionProblem],
+      entities: [
+        Problem,
+        Submission,
+        Competition,
+        User,
+        CompetitionProblem,
+        CompetitionParticipant,
+      ],
       logging: true,
     }),
     BullModule.forRoot({

--- a/be/algo-with-me-api/src/competition/competition.module.ts
+++ b/be/algo-with-me-api/src/competition/competition.module.ts
@@ -4,8 +4,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CompetitionController } from './controllers/competition.controller';
 import { ProblemController } from './controllers/problem.controller';
-import { CompetitionProblem } from './entities/competition.problem.entity';
 import { CompetitionParticipant } from './entities/competition.participant.entity';
+import { CompetitionProblem } from './entities/competition.problem.entity';
 import { Problem } from './entities/problem.entity';
 import { Submission } from './entities/submission.entity';
 import { CompetitionGateWay } from './gateways/competition.gateway';

--- a/be/algo-with-me-api/src/competition/competition.module.ts
+++ b/be/algo-with-me-api/src/competition/competition.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CompetitionController } from './controllers/competition.controller';
 import { ProblemController } from './controllers/problem.controller';
 import { CompetitionProblem } from './entities/competition.problem.entity';
+import { CompetitionParticipant } from './entities/competition.participant.entity';
 import { Problem } from './entities/problem.entity';
 import { Submission } from './entities/submission.entity';
 import { CompetitionGateWay } from './gateways/competition.gateway';
@@ -13,10 +14,18 @@ import { ProblemService } from './services/problem.service';
 import { SubmissionConsumer } from './tem.consumer';
 
 import { Competition } from '@src/competition/entities/competition.entity';
+import { User } from '@src/user/entities/user.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Problem, Submission, Competition, CompetitionProblem]),
+    TypeOrmModule.forFeature([
+      Problem,
+      Submission,
+      Competition,
+      CompetitionProblem,
+      CompetitionParticipant,
+      User,
+    ]),
     BullModule.registerQueue({
       name: process.env.REDIS_MESSAGE_QUEUE_NAME,
     }),

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -82,8 +82,8 @@ export class CompetitionController {
   @Get('problems/:problemId')
   @ApiOperation({ summary: '대회 문제 상세 조회' })
   @ApiResponse({ type: CompetitionProblemResponseDto })
-  findOneProblem(@Param('problemId') problemId: number) {
-    return this.competitionService.findOneProblem(problemId);
+  async findOneProblem(@Param('problemId') problemId: number) {
+    return await this.competitionService.findOneProblem(problemId);
   }
 
   @Post('scores')
@@ -93,8 +93,8 @@ export class CompetitionController {
       '**[프론트엔드에서는 사용되지 않음. 백엔드에서만 사용됨]** 채점 서버에서 테스트케이스 별로 채점이 완료될경우 호출할 api',
   })
   @UsePipes(new ValidationPipe({ transform: true }))
-  saveScoreResult(@Body() scoreResultDto: ScoreResultDto) {
-    this.competitionService.saveScoreResult(scoreResultDto);
+  async saveScoreResult(@Body() scoreResultDto: ScoreResultDto) {
+    await this.competitionService.saveScoreResult(scoreResultDto);
   }
 
   @Post('/:competitionId/participations')
@@ -104,8 +104,8 @@ export class CompetitionController {
   })
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  joinCompetition(@Req() req, @Param('competitionId') competitionId: number) {
-    this.competitionService.joinCompetition(competitionId, req.user.email);
+  async joinCompetition(@Req() req, @Param('competitionId') competitionId: number) {
+    await this.competitionService.joinCompetition(competitionId, req.user.email);
   }
 
   // @Post('submissions')

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -1,5 +1,17 @@
-import { Body, Controller, Get, Param, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { CompetitionProblemResponseDto } from '../dto/competition.problem.response.dto';
 import { CreateCompetitionDto } from '../dto/create-competition.dto';
@@ -83,6 +95,17 @@ export class CompetitionController {
   @UsePipes(new ValidationPipe({ transform: true }))
   saveScoreResult(@Body() scoreResultDto: ScoreResultDto) {
     this.competitionService.saveScoreResult(scoreResultDto);
+  }
+
+  @Post('/:competitionId/participations')
+  @ApiOperation({
+    summary: '대회 참여 api',
+    description: '유저가 대회에 참여하는 api 입니다.',
+  })
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  joinCompetition(@Req() req, @Param('competitionId') competitionId: number) {
+    this.competitionService.joinCompetition(competitionId, req.user.email);
   }
 
   // @Post('submissions')

--- a/be/algo-with-me-api/src/competition/dto/problem.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/problem.response.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { Problem } from '../entities/problem.entity';
+
 export class ProblemResponseDto {
   constructor(
     id: number,
@@ -34,4 +36,15 @@ export class ProblemResponseDto {
 
   @ApiProperty()
   createdAt: Date;
+
+  static from(problem: Problem, content: string) {
+    return new ProblemResponseDto(
+      problem.id,
+      problem.title,
+      problem.timeLimit,
+      problem.memoryLimit,
+      content,
+      problem.createdAt,
+    );
+  }
 }

--- a/be/algo-with-me-api/src/competition/entities/competition.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.entity.ts
@@ -7,8 +7,8 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { CompetitionParticipant } from './competition.participant.entity';
 import { CompetitionProblem } from './competition.problem.entity';
-import { CompetitionParticipant } from './participant.entity';
 import { Submission } from './submission.entity';
 
 @Entity()

--- a/be/algo-with-me-api/src/competition/entities/competition.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.entity.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import {
   Column,
   CreateDateColumn,
@@ -14,42 +13,32 @@ import { Submission } from './submission.entity';
 @Entity()
 export class Competition {
   @PrimaryGeneratedColumn()
-  @ApiProperty({ description: '대회 id' })
   id: number;
 
-  @ApiProperty({ description: '대회 이름' })
   @Column()
   name: string;
 
-  @ApiProperty({ description: '대회에 대한 설명글' })
   @Column('text')
   detail: string;
 
-  @ApiProperty({ description: '대회에 참여 가능한 최대 인원' })
   @Column()
   maxParticipants: number;
 
-  @ApiProperty({ description: '대회 시작 일시' })
   @Column()
   startsAt: Date;
 
-  @ApiProperty({ description: '대회 종료 일시' })
   @Column()
   endsAt: Date;
 
-  @ApiProperty({ description: '제출(submission) 테이블과 일대다 관계' })
   @OneToMany(() => Submission, (submission) => submission.competition)
   submissions: Submission[];
 
-  @ApiProperty({ description: '대회문제(competitionProblem) 테이블과 일대다 관계' })
   @OneToMany(() => CompetitionProblem, (competitionProblem) => competitionProblem.competition)
   competitionProblems: CompetitionProblem[];
 
-  @ApiProperty({ description: '레코드 생성 일시' })
   @CreateDateColumn()
   createdAt: Date;
 
-  @ApiProperty({ description: '레코드 수정 일시' })
   @UpdateDateColumn()
   updatedAt: Date;
 }

--- a/be/algo-with-me-api/src/competition/entities/competition.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 
 import { CompetitionProblem } from './competition.problem.entity';
+import { CompetitionParticipant } from './participant.entity';
 import { Submission } from './submission.entity';
 
 @Entity()
@@ -35,6 +36,12 @@ export class Competition {
 
   @OneToMany(() => CompetitionProblem, (competitionProblem) => competitionProblem.competition)
   competitionProblems: CompetitionProblem[];
+
+  @OneToMany(
+    () => CompetitionParticipant,
+    (competitionParticipant) => competitionParticipant.competition,
+  )
+  competitionParticipants: CompetitionParticipant[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
@@ -1,10 +1,11 @@
-import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
 import { Competition } from './competition.entity';
 
 import { User } from '@src/user/entities/user.entity';
 
 @Entity()
+@Unique('unique_participant', ['user', 'competition'])
 export class CompetitionParticipant {
   @PrimaryGeneratedColumn()
   id: number;

--- a/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
@@ -10,10 +10,10 @@ export class CompetitionParticipant {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => User, (user) => user.participants, {nullable: false})
+  @ManyToOne(() => User, (user) => user.competitionParticipant, {nullable: false})
   user: User;
 
-  @ManyToOne(() => Competition, (competition) => competition, {nullable: false})
+  @ManyToOne(() => Competition, (competition) => competition.competitionParticipants, {nullable: false})
   competition: Competition;
 
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
@@ -1,4 +1,11 @@
-import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
 
 import { Competition } from './competition.entity';
 
@@ -10,10 +17,18 @@ export class CompetitionParticipant {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => User, (user) => user.competitionParticipant, {nullable: false})
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => User, (user) => user.competitionParticipant, { nullable: false })
   user: User;
 
-  @ManyToOne(() => Competition, (competition) => competition.competitionParticipants, {nullable: false})
+  @Column()
+  competitionId: number;
+
+  @ManyToOne(() => Competition, (competition) => competition.competitionParticipants, {
+    nullable: false,
+  })
   competition: Competition;
 
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.participant.entity.ts
@@ -10,10 +10,10 @@ export class CompetitionParticipant {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => User, (user) => user.participants)
+  @ManyToOne(() => User, (user) => user.participants, {nullable: false})
   user: User;
 
-  @ManyToOne(() => Competition, (competition) => competition)
+  @ManyToOne(() => Competition, (competition) => competition, {nullable: false})
   competition: Competition;
 
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Competition } from './competition.entity';
@@ -7,14 +6,11 @@ import { Problem } from './problem.entity';
 @Entity()
 export class CompetitionProblem {
   @PrimaryGeneratedColumn()
-  @ApiProperty({ description: 'id' })
   id: number;
 
-  @ApiProperty({ description: '대회(competition) 테이블과 다대일 관계' })
   @ManyToOne(() => Competition, (competition) => competition.competitionProblems)
   competition: Competition;
 
-  @ApiProperty({ description: '문제(problem) 테이블과 다대일 관계' })
   @ManyToOne(() => Problem, (problem) => problem.competitionProblems)
   problem: Problem;
 

--- a/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/competition.problem.entity.ts
@@ -1,4 +1,4 @@
-import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Competition } from './competition.entity';
 import { Problem } from './problem.entity';
@@ -8,8 +8,14 @@ export class CompetitionProblem {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column()
+  competitionId: number;
+
   @ManyToOne(() => Competition, (competition) => competition.competitionProblems)
   competition: Competition;
+
+  @Column()
+  problemId: number;
 
   @ManyToOne(() => Problem, (problem) => problem.competitionProblems)
   problem: Problem;

--- a/be/algo-with-me-api/src/competition/entities/participant.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/participant.entity.ts
@@ -1,6 +1,20 @@
-import { Entity } from "typeorm";
+import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Competition } from './competition.entity';
+
+import { User } from '@src/user/entities/user.entity';
 
 @Entity()
-export class Participant {
-    
+export class CompetitionParticipant {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.participants)
+  user: User;
+
+  @ManyToOne(() => Competition, (competition) => competition)
+  competition: Competition;
+
+  @CreateDateColumn()
+  createdAt: Date;
 }

--- a/be/algo-with-me-api/src/competition/entities/participant.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/participant.entity.ts
@@ -1,0 +1,6 @@
+import { Entity } from "typeorm";
+
+@Entity()
+export class Participant {
+    
+}

--- a/be/algo-with-me-api/src/competition/entities/problem.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/problem.entity.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import {
   Column,
   CreateDateColumn,
@@ -14,46 +13,35 @@ import { Submission } from './submission.entity';
 @Entity()
 export class Problem {
   @PrimaryGeneratedColumn()
-  @ApiProperty()
   id: number;
 
-  @ApiProperty()
   @Column()
   title: string;
 
-  @ApiProperty()
   @Column()
   timeLimit: number;
 
-  @ApiProperty()
   @Column()
   memoryLimit: number;
 
-  @ApiProperty()
   @Column()
   testcaseNum: number;
 
-  @ApiProperty()
   @Column('text')
   frameCode: string;
 
-  @ApiProperty()
   @Column('text')
   solutionCode: string;
 
-  @ApiProperty()
   @OneToMany(() => Submission, (submission) => submission.problem)
   submissions: Submission[];
 
-  @ApiProperty({ description: '대회문제(competitionProblem) 테이블과 일대다 관계' })
   @OneToMany(() => CompetitionProblem, (competitionProblem) => competitionProblem.problem)
   competitionProblems: CompetitionProblem[];
 
-  @ApiProperty()
   @CreateDateColumn()
   createdAt: Date;
 
-  @ApiProperty()
   @UpdateDateColumn()
   updatedAt: Date;
 }

--- a/be/algo-with-me-api/src/competition/entities/submission.entity.ts
+++ b/be/algo-with-me-api/src/competition/entities/submission.entity.ts
@@ -29,10 +29,16 @@ export class Submission {
   @Column('json', { nullable: true, default: [] })
   detail: object[];
 
+  @Column()
+  problemId: number;
+
   @ManyToOne(() => Problem, (problem) => problem.submissions, { nullable: false })
   problem: Problem;
 
-  @ManyToOne(() => Competition, (competition) => competition.submissions)
+  @Column()
+  competitionId: number;
+
+  @ManyToOne(() => Competition, (competition) => competition.submissions, {nullable: false})
   competition: Competition;
 
   @CreateDateColumn()

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -112,13 +112,15 @@ export class CompetitionService {
     this.assertCompetitionExists(competition);
     const user: User = await this.userRepository.findOneBy({ email: email });
     if (!user) throw new NotFoundException('찾을 수 없는 유저입니다.');
-    console.log(user);
 
-    const isExist: CompetitionParticipant = await this.competitionParticipantRepository.findOneBy({
-      competition: competition,
-      user: user,
-    });
-    if (!isExist) throw new BadRequestException('이미 참여중인 유저입니다.');
+    const isAlreadyJoined: CompetitionParticipant[] =
+      await this.competitionParticipantRepository.find({
+        where: {
+          competition: { id: competition.id },
+          user: { id: user.id },
+        },
+      });
+    if (isAlreadyJoined.length !== 0) throw new BadRequestException('이미 참여중인 유저입니다.');
     this.competitionParticipantRepository.save({ competition: competition, user: user });
   }
 

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -116,8 +116,8 @@ export class CompetitionService {
     const isAlreadyJoined: CompetitionParticipant[] =
       await this.competitionParticipantRepository.find({
         where: {
-          competition: { id: competition.id },
-          user: { id: user.id },
+          competitionId: competition.id,
+          userId: user.id,
         },
       });
     if (isAlreadyJoined.length !== 0) throw new BadRequestException('이미 참여중인 유저입니다.');

--- a/be/algo-with-me-api/src/competition/services/problem.service.ts
+++ b/be/algo-with-me-api/src/competition/services/problem.service.ts
@@ -14,11 +14,11 @@ import { Problem } from '../entities/problem.entity';
 export class ProblemService {
   constructor(@InjectRepository(Problem) private readonly problemRepository: Repository<Problem>) {}
 
-  create(createProblemDto: CreateProblemDto) {
+  async create(createProblemDto: CreateProblemDto) {
     const problem: Problem = createProblemDto.toEntity();
 
-    const savedProblem = this.problemRepository.save(problem);
-    return savedProblem;
+    const savedProblem = await this.problemRepository.save(problem);
+    return ProblemResponseDto.from(savedProblem, '');
   }
 
   async findAll() {
@@ -34,14 +34,7 @@ export class ProblemService {
     const paths = path.join(process.env.PROBLEM_PATH, fileName);
     if (!existsSync(paths)) throw new NotFoundException('문제 파일을 찾을 수 없습니다.');
     const content = readFileSync(paths).toString();
-    return new ProblemResponseDto(
-      problem.id,
-      problem.title,
-      problem.timeLimit,
-      problem.memoryLimit,
-      content,
-      problem.createdAt,
-    );
+    return ProblemResponseDto.from(problem, content);
   }
 
   // update(id: number, updateCompetitionDto: UpdateCompetitionDto) {

--- a/be/algo-with-me-api/src/exception/exception.enum.ts
+++ b/be/algo-with-me-api/src/exception/exception.enum.ts
@@ -1,0 +1,4 @@
+export const ERROR_CODE = {
+  NOT_FOUND: 404,
+  BAD_REQUEST: 400,
+} as const;

--- a/be/algo-with-me-api/src/exception/service.exception.filter.ts
+++ b/be/algo-with-me-api/src/exception/service.exception.filter.ts
@@ -1,0 +1,20 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+import { Request, Response } from 'express';
+
+import { ServiceException } from './service.exception';
+
+@Catch(ServiceException)
+export class ServiceExceptionFilter implements ExceptionFilter {
+  catch(exception: ServiceException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const response = ctx.getResponse<Response>();
+    const status = exception.errorCode;
+
+    response.status(status).json({
+      statusCode: status,
+      message: exception.message,
+      path: request.url,
+    });
+  }
+}

--- a/be/algo-with-me-api/src/exception/service.exception.ts
+++ b/be/algo-with-me-api/src/exception/service.exception.ts
@@ -1,0 +1,17 @@
+import { ERROR_CODE } from './exception.enum';
+
+export const NotFoundException = (message?: string) => {
+  return new ServiceException(ERROR_CODE.NOT_FOUND, message);
+};
+
+export const BadRequestException = (message?: string) => {
+  return new ServiceException(ERROR_CODE.BAD_REQUEST, message);
+};
+
+export class ServiceException extends Error {
+  errorCode: number;
+  constructor(errorCode: number, message?: string) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}

--- a/be/algo-with-me-api/src/main.ts
+++ b/be/algo-with-me-api/src/main.ts
@@ -2,8 +2,6 @@ import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
-import { ServiceExceptionFilter } from './exception/service.exception.filter';
-
 import { AppModule } from '@src/app.module';
 
 function setSwagger(app: INestApplication<any>) {

--- a/be/algo-with-me-api/src/main.ts
+++ b/be/algo-with-me-api/src/main.ts
@@ -9,6 +9,7 @@ function setSwagger(app: INestApplication<any>) {
     .setTitle('algo-with-me-api')
     .setDescription('algo with me API description')
     .setVersion('1.0')
+    .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
@@ -16,7 +17,7 @@ function setSwagger(app: INestApplication<any>) {
 }
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {cors: true});
+  const app = await NestFactory.create(AppModule, { cors: true });
   setSwagger(app);
   await app.listen(3000);
 }

--- a/be/algo-with-me-api/src/main.ts
+++ b/be/algo-with-me-api/src/main.ts
@@ -2,6 +2,8 @@ import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
+import { ServiceExceptionFilter } from './exception/service.exception.filter';
+
 import { AppModule } from '@src/app.module';
 
 function setSwagger(app: INestApplication<any>) {
@@ -18,6 +20,7 @@ function setSwagger(app: INestApplication<any>) {
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { cors: true });
+  // app.useGlobalFilters(new ServiceExceptionFilter());
   setSwagger(app);
   await app.listen(3000);
 }

--- a/be/algo-with-me-api/src/user/entities/user.entity.ts
+++ b/be/algo-with-me-api/src/user/entities/user.entity.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail } from 'class-validator';
 import {
   Column,
@@ -10,24 +9,19 @@ import {
 
 @Entity()
 export class User {
-  @ApiProperty({ description: '유저 id' })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ description: '이메일' })
   @Column()
   @IsEmail()
   email: string;
 
-  @ApiProperty({ description: '닉네임 초기값은 이메일' })
   @Column()
   nickname: string;
 
-  @ApiProperty({ description: '생성일' })
   @CreateDateColumn()
   createdAt: Date;
 
-  @ApiProperty({ description: '수정일' })
   @UpdateDateColumn()
   updatedAt: Date;
 }

--- a/be/algo-with-me-api/src/user/entities/user.entity.ts
+++ b/be/algo-with-me-api/src/user/entities/user.entity.ts
@@ -23,7 +23,7 @@ export class User {
   nickname: string;
 
   @OneToMany(() => CompetitionParticipant, (competitionParticipant) => competitionParticipant.user)
-  participants: CompetitionParticipant[];
+  competitionParticipant: CompetitionParticipant[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/be/algo-with-me-api/src/user/entities/user.entity.ts
+++ b/be/algo-with-me-api/src/user/entities/user.entity.ts
@@ -8,7 +8,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-import { CompetitionParticipant } from '@src/competition/entities/participant.entity';
+import { CompetitionParticipant } from '@src/competition/entities/competition.participant.entity';
 
 @Entity()
 export class User {

--- a/be/algo-with-me-api/src/user/entities/user.entity.ts
+++ b/be/algo-with-me-api/src/user/entities/user.entity.ts
@@ -3,9 +3,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+
+import { CompetitionParticipant } from '@src/competition/entities/participant.entity';
 
 @Entity()
 export class User {
@@ -18,6 +21,9 @@ export class User {
 
   @Column()
   nickname: string;
+
+  @OneToMany(() => CompetitionParticipant, (competitionParticipant) => competitionParticipant.user)
+  participants: CompetitionParticipant[];
 
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
- entity를 반환하던 service 로직을 dto를 반환하도록 수정했습니다.
- 대회 참여 api 구현했습니다.
    - 유저-대회 엔티티를 competition 폴더에 생성했습니다.

- swagger 관련 수정
    - entity는 client에게 보여질 일이 없으므로 엔티티에 붙어있는 swagger 데코레이터를 삭제했습니다.
    - 대회 참여를 위해 유저 인증이 필요한데, swagger에서 토큰으로 인증할 수 있도록 하였습니다.

- service에서 발생하는 에러가 자꾸 내부 서버에러로 서버가 죽어버리는 문제가 발생했습니다.
    - custom error handling을 해주어 문제를 해결하려고 시도했습니다.
    - 알고보니 컨트롤러에서 service 로직을 호출하고 await을 하지 않아 filter에 걸리지 않아 에러를 처리하지 못하는 것으로 확인했습니다.
    - custom error handling 코드는 추후 사용가능성이 있으므로 삭제하지 않고 사용하지 않는 상태로 놔두려고 합니다.