### PR TITLE
[#79] 웹 소켓 정상작동 시에 연결

### DIFF
--- a/frontend/src/components/Common/Loading.tsx
+++ b/frontend/src/components/Common/Loading.tsx
@@ -17,9 +17,9 @@ export default function Loading({ size, color }: Props) {
         cy="50"
         fill="none"
         stroke={color}
-        stroke-width="10"
+        strokeWidth="10"
         r="35"
-        stroke-dasharray="164.93361431346415 56.97787143782138"
+        strokeDasharray="164.93361431346415 56.97787143782138"
       >
         <animateTransform
           attributeName="transform"

--- a/frontend/src/components/SocketTimer/index.tsx
+++ b/frontend/src/components/SocketTimer/index.tsx
@@ -16,8 +16,7 @@ interface Props {
 
 export default function SocketTimer(props: Props) {
   let { socket, endsAt, isConnected, onTimeout } = props;
-  // api 연결이 X endsAt 대신 임시로 만들어놓은 것.
-  // min 1 => 60초 동안 돌아갑니다. 변경해서 쓰세요 일단은..
+  // 대회 시간 검증이 안 되어 있어서, 끝나는 시간이 현재 시간보다 모두 전입니다. 그래서 지금 시간 기준으로 120분 더하고 마지막 시간이다라고 가정합니다.
   const min = 120;
   endsAt = new Date(new Date().getTime() + min * 60 * 1000);
 
@@ -25,6 +24,7 @@ export default function SocketTimer(props: Props) {
     socket,
     endsAt,
     socketEvent: 'ping',
+    pingTime: 5000,
   });
 
   useEffect(() => {

--- a/frontend/src/components/SocketTimer/index.tsx
+++ b/frontend/src/components/SocketTimer/index.tsx
@@ -11,11 +11,13 @@ interface Props {
   socket: Socket;
   isConnected: boolean;
   endsAt: Date;
+  pingTime: number;
+  socketEvent: string;
   onTimeout?: () => void;
 }
 
 export default function SocketTimer(props: Props) {
-  let { socket, endsAt, isConnected, onTimeout } = props;
+  let { socket, endsAt, isConnected, onTimeout, pingTime, socketEvent } = props;
   // 대회 시간 검증이 안 되어 있어서, 끝나는 시간이 현재 시간보다 모두 전입니다. 그래서 지금 시간 기준으로 120분 더하고 마지막 시간이다라고 가정합니다.
   const min = 120;
   endsAt = new Date(new Date().getTime() + min * 60 * 1000);
@@ -23,8 +25,8 @@ export default function SocketTimer(props: Props) {
   const { remainMiliSeconds, isTimeout } = useSocketTimer({
     socket,
     endsAt,
-    socketEvent: 'ping',
-    pingTime: 5000,
+    socketEvent,
+    pingTime,
   });
 
   useEffect(() => {

--- a/frontend/src/hooks/timer/useSocketTimer.ts
+++ b/frontend/src/hooks/timer/useSocketTimer.ts
@@ -18,6 +18,8 @@ export default function useSocketTimer({ socket, endsAt, socketEvent, pingTime }
   const [remainMiliSeconds, setRemainMiliSeconds] = useState<number>(-1);
 
   useEffect(() => {
+    if (pingIntervalId.current) clearInterval(pingIntervalId.current);
+
     socket.emit(socketEvent);
     socket.on(socketEvent, handlePingMessage);
 
@@ -50,5 +52,6 @@ export default function useSocketTimer({ socket, endsAt, socketEvent, pingTime }
       setIsTimeout(true);
     }
   }, [remainMiliSeconds]);
+
   return { remainMiliSeconds, isTimeout };
 }

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -24,6 +24,8 @@ import { isNil } from '@/utils/type';
 const RUN_SIMULATION = '테스트 실행';
 const CANCEL_SIMULATION = '실행 취소';
 const DASHBOARD_URL = '/contest/dashboard';
+const COMPEITION_PING_TIME = 5 * 1000;
+const COMPEITION_SOCKET_EVENT = 'ping';
 
 export default function ContestPage() {
   const { id } = useParams<{ id: string }>();
@@ -107,6 +109,8 @@ export default function ContestPage() {
           socket={socket.current}
           isConnected={isConnected}
           endsAt={new Date(endsAt)}
+          pingTime={COMPEITION_PING_TIME}
+          socketEvent={COMPEITION_SOCKET_EVENT}
           onTimeout={handleTimeout}
         />
       </section>


### PR DESCRIPTION
### 한 일
- mockWebSocket => 실제 webSocket으로 변경
  - 필요업는 코드 삭제
- loading component에 - 들어간  프로퍼티 네임 카멜 케이즈로 변경
 
### 실제 화면
- 웹 소켓 끊겼다가 다시 연결 되어도 타이머 정상 작동하는지 체크
- <React.StrictMode>를 off하고 했습니다. 

https://github.com/boostcampwm2023/web12-algo-with-me/assets/78193416/3e265cea-f853-4d92-b14a-2782ecdbd968

