### PR TITLE
[#139] 대회 세부정보 페이지 추가 구현

### DIFF
--- a/frontend/src/apis/competitions/types.ts
+++ b/frontend/src/apis/competitions/types.ts
@@ -13,6 +13,8 @@ export type CompetitionForm = {
 
 export type CompetitionInfo = {
   id: CompetitionId;
+  host: string;
+  participants: string[];
   name: string;
   detail: string;
   maxParticipants: number;

--- a/frontend/src/apis/competitions/types.ts
+++ b/frontend/src/apis/competitions/types.ts
@@ -13,7 +13,7 @@ export type CompetitionForm = {
 
 export type CompetitionInfo = {
   id: CompetitionId;
-  host: string;
+  host: string | null;
   participants: string[];
   name: string;
   detail: string;

--- a/frontend/src/components/Common/Logo.tsx
+++ b/frontend/src/components/Common/Logo.tsx
@@ -4,6 +4,5 @@ interface Props {
 
 export default function Logo({ size }: Props) {
   // public이란 곳에 리소스 넣어두면 build시에 바로 밑에 생기기 때문에 ./으로 접근 가능합니다.
-  // MainPage에서는 logo를 불러올 수 있는데, CompetitionDetailPage에서 불러오지 못해 아래와 같이 변경(이우찬)
-  return <img src="../../../public/algo.png" alt="logo" width={size} height={size} />;
+  return <img src="./algo.png" alt="logo" width={size} height={size} />;
 }

--- a/frontend/src/components/Common/Logo.tsx
+++ b/frontend/src/components/Common/Logo.tsx
@@ -4,5 +4,6 @@ interface Props {
 
 export default function Logo({ size }: Props) {
   // public이란 곳에 리소스 넣어두면 build시에 바로 밑에 생기기 때문에 ./으로 접근 가능합니다.
-  return <img src="./algo.png" alt="logo" width={size} height={size} />;
+  // MainPage에서는 logo를 불러올 수 있는데, CompetitionDetailPage에서 불러오지 못해 아래와 같이 변경(이우찬)
+  return <img src="../../../public/algo.png" alt="logo" width={size} height={size} />;
 }

--- a/frontend/src/components/CompetitionDetail/AfterCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/AfterCompetition.tsx
@@ -26,7 +26,7 @@ export default function AfterCompetition({
       />
 
       <ProblemList competitionId={competitionId} />
-      <CompetitionMembersInfo host={competition.host} members={competition.participants} />
+      <CompetitionMembersInfo competition={competition} />
     </div>
   );
 }

--- a/frontend/src/components/CompetitionDetail/AfterCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/AfterCompetition.tsx
@@ -18,21 +18,45 @@ export default function AfterCompetition({
   competition,
   competitionSchedule,
 }: Props) {
+  const formattedParticipants = competition.participants.join(', ');
+
   return (
-    <div className={containerStyle}>
+    <div>
       <CompetitionDetailInfo
         competition={competition}
         text={AFTER_COMPETITION_TEXT}
         competitionSchedule={competitionSchedule}
       />
+
       <ProblemList competitionId={competitionId} />
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 생성자</div>
+        <div className={contentStyle}>{competition.host}</div>
+      </div>
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 참여자</div>
+        <div className={contentStyle}>{formattedParticipants}</div>
+      </div>
     </div>
   );
 }
 
 const containerStyle = css({
-  justifyContent: 'space-between',
-  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: '16px',
   padding: '16px',
   border: '1px solid #ccc',
+});
+
+const headerStyle = css({
+  fontSize: '18px',
+  fontWeight: 'bold',
+  marginBottom: '8px',
+});
+
+const contentStyle = css({
+  fontSize: '16px',
 });

--- a/frontend/src/components/CompetitionDetail/AfterCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/AfterCompetition.tsx
@@ -1,8 +1,7 @@
-import { css } from '@style/css';
-
 import { CompetitionInfo } from '@/apis/competitions';
 
 import CompetitionDetailInfo from './CompetitionDetailInfo';
+import CompetitionMembersInfo from './CompetitionMembersInfo';
 import ProblemList from './ProblemList';
 
 interface Props {
@@ -18,8 +17,6 @@ export default function AfterCompetition({
   competition,
   competitionSchedule,
 }: Props) {
-  const formattedParticipants = competition.participants.join(', ');
-
   return (
     <div>
       <CompetitionDetailInfo
@@ -29,34 +26,7 @@ export default function AfterCompetition({
       />
 
       <ProblemList competitionId={competitionId} />
-
-      <div className={containerStyle}>
-        <div className={headerStyle}>대회 생성자</div>
-        <div className={contentStyle}>{competition.host}</div>
-      </div>
-
-      <div className={containerStyle}>
-        <div className={headerStyle}>대회 참여자</div>
-        <div className={contentStyle}>{formattedParticipants}</div>
-      </div>
+      <CompetitionMembersInfo host={competition.host} members={competition.participants} />
     </div>
   );
 }
-
-const containerStyle = css({
-  display: 'flex',
-  flexDirection: 'column',
-  marginTop: '16px',
-  padding: '16px',
-  border: '1px solid #ccc',
-});
-
-const headerStyle = css({
-  fontSize: '18px',
-  fontWeight: 'bold',
-  marginBottom: '8px',
-});
-
-const contentStyle = css({
-  fontSize: '16px',
-});

--- a/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
@@ -5,6 +5,7 @@ import { CompetitionInfo } from '@/apis/competitions';
 import JoinCompetitionButton from '../Main/Buttons/JoinCompetitionButton';
 import EnterCompetitionButton from './Buttons/EnterCompetitionButton';
 import CompetitionDetailInfo from './CompetitionDetailInfo';
+import CompetitionMembersInfo from './CompetitionMembersInfo';
 
 interface Props {
   competitionId: number;
@@ -22,7 +23,6 @@ export default function BeforeCompetition({
   competitionSchedule,
 }: Props) {
   const BEFORE_COMPETITION_TEXT = ` 시작 전`;
-  const formattedParticipants = competition.participants.join(', ');
 
   return (
     <div>
@@ -37,36 +37,10 @@ export default function BeforeCompetition({
         <EnterCompetitionButton id={competitionId} startsAt={startsAt} endsAt={endsAt} />
       </div>
 
-      <div className={containerStyle}>
-        <div className={headerStyle}>대회 생성자</div>
-        <div className={contentStyle}>{competition.host}</div>
-      </div>
-
-      <div className={containerStyle}>
-        <div className={headerStyle}>대회 참여자</div>
-        <div className={contentStyle}>{formattedParticipants}</div>
-      </div>
+      <CompetitionMembersInfo host={competition.host} members={competition.participants} />
     </div>
   );
 }
-
-const containerStyle = css({
-  display: 'flex',
-  flexDirection: 'column',
-  marginTop: '16px',
-  padding: '16px',
-  border: '1px solid #ccc',
-});
-
-const headerStyle = css({
-  fontSize: '18px',
-  fontWeight: 'bold',
-  marginBottom: '8px',
-});
-
-const contentStyle = css({
-  fontSize: '16px',
-});
 
 const buttonContainerStyle = css({
   display: 'flex',

--- a/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
@@ -37,7 +37,7 @@ export default function BeforeCompetition({
         <EnterCompetitionButton id={competitionId} startsAt={startsAt} endsAt={endsAt} />
       </div>
 
-      <CompetitionMembersInfo host={competition.host} members={competition.participants} />
+      <CompetitionMembersInfo competition={competition} />
     </div>
   );
 }

--- a/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
@@ -22,27 +22,50 @@ export default function BeforeCompetition({
   competitionSchedule,
 }: Props) {
   const BEFORE_COMPETITION_TEXT = ` 시작 전`;
+  const formattedParticipants = competition.participants.join(', ');
 
   return (
-    <div className={containerStyle}>
+    <div>
       <CompetitionDetailInfo
         competition={competition}
         text={BEFORE_COMPETITION_TEXT}
         competitionSchedule={competitionSchedule}
       />
+
       <div className={buttonContainerStyle}>
         <JoinCompetitionButton id={competitionId} />
         <EnterCompetitionButton id={competitionId} startsAt={startsAt} endsAt={endsAt} />
+      </div>
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 생성자</div>
+        <div className={contentStyle}>{competition.host}</div>
+      </div>
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 참여자</div>
+        <div className={contentStyle}>{formattedParticipants}</div>
       </div>
     </div>
   );
 }
 
 const containerStyle = css({
-  justifyContent: 'space-between',
-  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: '16px',
   padding: '16px',
   border: '1px solid #ccc',
+});
+
+const headerStyle = css({
+  fontSize: '18px',
+  fontWeight: 'bold',
+  marginBottom: '8px',
+});
+
+const contentStyle = css({
+  fontSize: '16px',
 });
 
 const buttonContainerStyle = css({

--- a/frontend/src/components/CompetitionDetail/CompetitionMembersInfo.tsx
+++ b/frontend/src/components/CompetitionDetail/CompetitionMembersInfo.tsx
@@ -1,0 +1,42 @@
+import { css } from '@style/css';
+
+interface Props {
+  host: string;
+  members: string[];
+}
+
+export default function CompetitionMembersInfo({ host, members }: Props) {
+  const formattedMembers = members.join(', ');
+
+  return (
+    <div>
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 생성자</div>
+        <div className={contentStyle}>{host}</div>
+      </div>
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 참여자</div>
+        <div className={contentStyle}>{formattedMembers}</div>
+      </div>
+    </div>
+  );
+}
+
+const containerStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: '16px',
+  padding: '16px',
+  border: '1px solid #ccc',
+});
+
+const headerStyle = css({
+  fontSize: '18px',
+  fontWeight: 'bold',
+  marginBottom: '8px',
+});
+
+const contentStyle = css({
+  fontSize: '16px',
+});

--- a/frontend/src/components/CompetitionDetail/CompetitionMembersInfo.tsx
+++ b/frontend/src/components/CompetitionDetail/CompetitionMembersInfo.tsx
@@ -1,12 +1,14 @@
 import { css } from '@style/css';
 
+import { CompetitionInfo } from '@/apis/competitions';
+
 interface Props {
-  host: string;
-  members: string[];
+  competition: CompetitionInfo;
 }
 
-export default function CompetitionMembersInfo({ host, members }: Props) {
-  const formattedMembers = members.join(', ');
+export default function CompetitionMembersInfo({ competition }: Props) {
+  const formattedMembers = competition.participants.join(', ');
+  const host = competition.host || 'None';
 
   return (
     <section>

--- a/frontend/src/components/CompetitionDetail/CompetitionMembersInfo.tsx
+++ b/frontend/src/components/CompetitionDetail/CompetitionMembersInfo.tsx
@@ -9,17 +9,17 @@ export default function CompetitionMembersInfo({ host, members }: Props) {
   const formattedMembers = members.join(', ');
 
   return (
-    <div>
+    <section>
       <div className={containerStyle}>
-        <div className={headerStyle}>대회 생성자</div>
-        <div className={contentStyle}>{host}</div>
+        <header className={headerStyle}>대회 생성자</header>
+        <p className={contentStyle}>{host}</p>
       </div>
 
       <div className={containerStyle}>
-        <div className={headerStyle}>대회 참여자</div>
-        <div className={contentStyle}>{formattedMembers}</div>
+        <header className={headerStyle}>대회 참여자</header>
+        <p className={contentStyle}>{formattedMembers}</p>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/frontend/src/components/CompetitionDetail/DuringCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/DuringCompetition.tsx
@@ -22,21 +22,45 @@ export default function DuringCompetition({
   endsAt,
   competitionSchedule,
 }: Props) {
+  const formattedParticipants = competition.participants.join(', ');
+
   return (
-    <div className={containerStyle}>
+    <div>
       <CompetitionDetailInfo
         competition={competition}
         text={DURING_COMPETITION_TEXT}
         competitionSchedule={competitionSchedule}
       />
+
       <EnterCompetitionButton id={competitionId} startsAt={startsAt} endsAt={endsAt} />
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 생성자</div>
+        <div className={contentStyle}>{competition.host}</div>
+      </div>
+
+      <div className={containerStyle}>
+        <div className={headerStyle}>대회 참여자</div>
+        <div className={contentStyle}>{formattedParticipants}</div>
+      </div>
     </div>
   );
 }
 
 const containerStyle = css({
-  justifyContent: 'space-between',
-  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: '16px',
   padding: '16px',
   border: '1px solid #ccc',
+});
+
+const headerStyle = css({
+  fontSize: '18px',
+  fontWeight: 'bold',
+  marginBottom: '8px',
+});
+
+const contentStyle = css({
+  fontSize: '16px',
 });

--- a/frontend/src/components/CompetitionDetail/DuringCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/DuringCompetition.tsx
@@ -31,7 +31,7 @@ export default function DuringCompetition({
 
       <EnterCompetitionButton id={competitionId} startsAt={startsAt} endsAt={endsAt} />
 
-      <CompetitionMembersInfo host={competition.host} members={competition.participants} />
+      <CompetitionMembersInfo competition={competition} />
     </div>
   );
 }

--- a/frontend/src/components/CompetitionDetail/DuringCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/DuringCompetition.tsx
@@ -1,9 +1,8 @@
-import { css } from '@style/css';
-
 import { CompetitionInfo } from '@/apis/competitions';
 
 import EnterCompetitionButton from './Buttons/EnterCompetitionButton';
 import CompetitionDetailInfo from './CompetitionDetailInfo';
+import CompetitionMembersInfo from './CompetitionMembersInfo';
 
 interface Props {
   competitionId: number;
@@ -22,8 +21,6 @@ export default function DuringCompetition({
   endsAt,
   competitionSchedule,
 }: Props) {
-  const formattedParticipants = competition.participants.join(', ');
-
   return (
     <div>
       <CompetitionDetailInfo
@@ -34,33 +31,7 @@ export default function DuringCompetition({
 
       <EnterCompetitionButton id={competitionId} startsAt={startsAt} endsAt={endsAt} />
 
-      <div className={containerStyle}>
-        <div className={headerStyle}>대회 생성자</div>
-        <div className={contentStyle}>{competition.host}</div>
-      </div>
-
-      <div className={containerStyle}>
-        <div className={headerStyle}>대회 참여자</div>
-        <div className={contentStyle}>{formattedParticipants}</div>
-      </div>
+      <CompetitionMembersInfo host={competition.host} members={competition.participants} />
     </div>
   );
 }
-
-const containerStyle = css({
-  display: 'flex',
-  flexDirection: 'column',
-  marginTop: '16px',
-  padding: '16px',
-  border: '1px solid #ccc',
-});
-
-const headerStyle = css({
-  fontSize: '18px',
-  fontWeight: 'bold',
-  marginBottom: '8px',
-});
-
-const contentStyle = css({
-  fontSize: '16px',
-});

--- a/frontend/src/hooks/competition/useCompetition.ts
+++ b/frontend/src/hooks/competition/useCompetition.ts
@@ -14,8 +14,8 @@ export type SubmissionForm = {
 
 const notFoundCompetition: CompetitionInfo = {
   id: 0,
-  host: 'None',
-  participants: ['None'],
+  host: null,
+  participants: [],
   name: 'Competition Not Found',
   detail: 'Competition Not Found',
   maxParticipants: 0,

--- a/frontend/src/hooks/competition/useCompetition.ts
+++ b/frontend/src/hooks/competition/useCompetition.ts
@@ -14,6 +14,8 @@ export type SubmissionForm = {
 
 const notFoundCompetition: CompetitionInfo = {
   id: 0,
+  host: 'None',
+  participants: ['None'],
   name: 'Competition Not Found',
   detail: 'Competition Not Found',
   maxParticipants: 0,


### PR DESCRIPTION
### 한 일
대회 세부정보 페이지에서 대회 생성자와 참여자를 보여줍니다.

### 스크린샷
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/a5aad099-9ee5-4b6e-b6ed-0724e6bd1527)
