### PR TITLE
[#129] 테스트 케이스 추가삭제 훅 생성

### DIFF
--- a/frontend/src/components/Common/Modal/Modal.tsx
+++ b/frontend/src/components/Common/Modal/Modal.tsx
@@ -60,7 +60,7 @@ const dialogStyle = css({
   left: '50%',
   top: '50%',
   transform: 'translate(-50%,-50%)',
-  width: '500px',
+  width: '600px',
   height: '400px',
   _backdrop: {
     background: 'rgba(00,00,00,0.5)',

--- a/frontend/src/components/Simulation/SimulationInputList.tsx
+++ b/frontend/src/components/Simulation/SimulationInputList.tsx
@@ -4,27 +4,41 @@ import type { ChangeEvent, HTMLAttributes } from 'react';
 
 import type { SimulationInput } from '@/hooks/simulation';
 
+import type { InputChangeProps } from './SimulationInputModal';
+
 interface Props extends HTMLAttributes<HTMLUListElement> {
   inputList: SimulationInput[];
-  onChangeInput: (index: number, newInput: string) => void;
+  onChangeInput: ({ dataType, newInput, dataIndex }: InputChangeProps) => void;
+  onDeleteInput: (index: number) => void;
 }
 
 export function SimulationInputList(props: Props) {
-  const { inputList, onChangeInput, ...rest } = props;
+  const { inputList, onChangeInput, onDeleteInput, ...rest } = props;
 
-  const handleInputChange = (index: number, newInput: string) => {
-    onChangeInput(index, newInput);
+  const handleChange = ({ dataType, newInput, dataIndex }: InputChangeProps) => {
+    onChangeInput({ dataType, newInput, dataIndex });
   };
 
   return (
     <ul {...rest}>
-      {inputList.map(({ input, id }, index) => (
+      {inputList.map(({ input, expected, id, changable }, index) => (
         <li key={id} className={listStyle}>
           케이스 {index}:
           <SimulationInput
+            dataIndex={index + 1}
+            dataType="input"
             value={input}
-            onChange={(newInput) => handleInputChange(id, newInput)}
+            onChange={handleChange}
+            changable={changable as boolean}
           ></SimulationInput>
+          <SimulationInput
+            dataIndex={index + 1}
+            dataType="expected"
+            value={expected as string}
+            onChange={handleChange}
+            changable={changable as boolean}
+          ></SimulationInput>
+          {changable && <button onClick={() => onDeleteInput(id)}>-</button>}
         </li>
       ))}
     </ul>
@@ -33,24 +47,31 @@ export function SimulationInputList(props: Props) {
 
 interface SimulationInputProps {
   value: string;
-  onChange: (newInput: string) => void;
+  dataIndex: number;
+  dataType: string;
+  changable: boolean;
+  onChange: ({ dataType, newInput, dataIndex }: InputChangeProps) => void;
 }
 
 const SimulationInput = (props: SimulationInputProps) => {
-  const { value, onChange } = props;
+  const { value, onChange, dataIndex, dataType, changable } = props;
 
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
     const newInput = e.target.value;
     if (onChange) {
-      onChange(newInput);
+      onChange({ newInput, dataIndex, dataType });
     }
   };
-
+  if (!changable) {
+    return <input value={value} className={inputStyle} onChange={handleInput} disabled></input>;
+  }
   return <input value={value} className={inputStyle} onChange={handleInput}></input>;
 };
 
 const listStyle = css({
   marginBottom: '0.25rem',
+  display: 'flex',
+  gap: '0.5rem',
 });
 
 const inputStyle = css({

--- a/frontend/src/components/Simulation/SimulationInputList.tsx
+++ b/frontend/src/components/Simulation/SimulationInputList.tsx
@@ -8,36 +8,37 @@ import type { InputChangeProps } from './SimulationInputModal';
 
 interface Props extends HTMLAttributes<HTMLUListElement> {
   inputList: SimulationInput[];
-  onChangeInput: ({ dataType, newInput, dataIndex }: InputChangeProps) => void;
+  onChangeInput: ({ testcaseId, newInput, testcaseType }: InputChangeProps) => void;
   onDeleteInput: (index: number) => void;
 }
 
 export function SimulationInputList(props: Props) {
   const { inputList, onChangeInput, onDeleteInput, ...rest } = props;
 
-  const handleChange = ({ dataType, newInput, dataIndex }: InputChangeProps) => {
-    onChangeInput({ dataType, newInput, dataIndex });
+  const handleChange = ({ testcaseId, newInput, testcaseType }: InputChangeProps) => {
+    onChangeInput({ testcaseId, newInput, testcaseType });
   };
 
   return (
     <ul {...rest}>
       {inputList.map(({ input, expected, id, changable }, index) => (
         <li key={id} className={listStyle}>
-          케이스 {index}:
-          <SimulationInput
-            dataIndex={index + 1}
-            dataType="input"
+          인풋{index}:
+          <Input
+            testcaseId={index + 1}
+            testcaseType="input"
             value={input}
             onChange={handleChange}
             changable={changable as boolean}
-          ></SimulationInput>
-          <SimulationInput
-            dataIndex={index + 1}
-            dataType="expected"
+          ></Input>
+          예상{index}:
+          <Input
+            testcaseId={index + 1}
+            testcaseType="expected"
             value={expected as string}
             onChange={handleChange}
             changable={changable as boolean}
-          ></SimulationInput>
+          ></Input>
           {changable && <button onClick={() => onDeleteInput(id)}>-</button>}
         </li>
       ))}
@@ -47,19 +48,19 @@ export function SimulationInputList(props: Props) {
 
 interface SimulationInputProps {
   value: string;
-  dataIndex: number;
-  dataType: string;
+  testcaseId: number;
+  testcaseType: string;
   changable: boolean;
-  onChange: ({ dataType, newInput, dataIndex }: InputChangeProps) => void;
+  onChange: ({ testcaseId, newInput, testcaseType }: InputChangeProps) => void;
 }
 
-const SimulationInput = (props: SimulationInputProps) => {
-  const { value, onChange, dataIndex, dataType, changable } = props;
+const Input = (props: SimulationInputProps) => {
+  const { value, onChange, testcaseId, testcaseType, changable } = props;
 
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
     const newInput = e.target.value;
     if (onChange) {
-      onChange({ newInput, dataIndex, dataType });
+      onChange({ newInput, testcaseId, testcaseType });
     }
   };
   if (!changable) {

--- a/frontend/src/components/Simulation/SimulationInputModal.tsx
+++ b/frontend/src/components/Simulation/SimulationInputModal.tsx
@@ -85,7 +85,6 @@ export function SimulationInputModal({ simulationInputs, onSave, ...props }: Pro
   };
 
   const handleChangeInput = ({ newInput, dataIndex, dataType }: InputChangeProps) => {
-    console.log(newInput, dataIndex, dataType);
     const changedInput = inputs.find(({ id }) => id === dataIndex);
     if (!changedInput) return;
     const originInputs = deepCopy(inputs);
@@ -117,7 +116,7 @@ export function SimulationInputModal({ simulationInputs, onSave, ...props }: Pro
         <section>
           <div className={rowStyle}>
             <div>Parameters</div>
-            <button onClick={handleClickAddButton}>+추가</button>
+            <button onClick={handleClickAddButton}>+ 추가</button>
           </div>
           <SimulationInputList
             inputList={inputs}

--- a/frontend/src/components/Simulation/SimulationInputModal.tsx
+++ b/frontend/src/components/Simulation/SimulationInputModal.tsx
@@ -14,9 +14,9 @@ interface Props extends ModalProps {
 }
 
 interface InputChangeProps {
-  dataType: string;
+  testcaseType: string;
   newInput: string;
-  dataIndex: number;
+  testcaseId: number;
 }
 
 const MAX_INPUT_COUNT = 10;
@@ -84,17 +84,17 @@ export function SimulationInputModal({ simulationInputs, onSave, ...props }: Pro
     ]);
   };
 
-  const handleChangeInput = ({ newInput, dataIndex, dataType }: InputChangeProps) => {
-    const changedInput = inputs.find(({ id }) => id === dataIndex);
+  const handleChangeInput = ({ newInput, testcaseId, testcaseType }: InputChangeProps) => {
+    const changedInput = inputs.find(({ id }) => id === testcaseId);
     if (!changedInput) return;
     const originInputs = deepCopy(inputs);
-    if (dataType === 'input') {
+    if (testcaseType === 'input') {
       changedInput.input = newInput;
     }
-    if (dataType === 'expected') {
+    if (testcaseType === 'expected') {
       changedInput.expected = newInput;
     }
-    originInputs[dataIndex - 1] = changedInput;
+    originInputs[testcaseId - 1] = changedInput;
     setInputs([...originInputs]);
   };
 

--- a/frontend/src/components/Simulation/SimulationInputModal.tsx
+++ b/frontend/src/components/Simulation/SimulationInputModal.tsx
@@ -1,4 +1,6 @@
-import { useContext, useState } from 'react';
+import { css, cx } from '@style/css';
+
+import { useContext, useMemo, useState } from 'react';
 
 import type { SimulationInput } from '@/hooks/simulation';
 import { deepCopy } from '@/utils/copy';
@@ -11,36 +13,145 @@ interface Props extends ModalProps {
   onSave: (inputs: SimulationInput[]) => void;
 }
 
+interface InputChangeProps {
+  dataType: string;
+  newInput: string;
+  dataIndex: number;
+}
+
+const MAX_INPUT_COUNT = 10;
+
 export function SimulationInputModal({ simulationInputs, onSave, ...props }: Props) {
   const modal = useContext(Modal.Context);
+
+  // 현재 simulationInputs는 {id:1,input:''}[] 형태임
+  // 프로그래머스에서 parameters와 return으로 나누고 있으나
+  // algoWithMe는 parameters => input return => expected로 바꿔서 생각함.
+  // 서버에서 보내주는 테스트 케이스를 받자마자 changable : false라고 해놓고 사용자가 추가한 테스트 케이스는 true라고 해서 삭제 검증할 때 사용하면 편함.
+  // Contest page에서 testcase를 fetch해서 changable : false 까지 추가해서 보내준 상황으로 생각하고 구현함.
+
+  simulationInputs = [
+    { id: 1, input: '11', expected: '111', changable: false },
+    { id: 2, input: '22', expected: '222', changable: false },
+  ];
   const [inputs, setInputs] = useState<SimulationInput[]>(deepCopy(simulationInputs));
 
+  const copyInputs = useMemo(() => {
+    return deepCopy(simulationInputs);
+  }, []);
+
   const handleCloseModal = () => {
-    setInputs(simulationInputs);
+    // simulationInputsr가 처음들어올 떄의 값을 저장하고 닫기를 누르면 그 값으로 돌아가게 함.
+    setInputs(deepCopy(copyInputs));
     modal.close();
+  };
+
+  // input 다 채웠냐
+  const isFilled = () => {
+    for (const { input, expected } of inputs) {
+      if (input === '' || expected === '') {
+        alert('빈칸을 채워주세요');
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // 정해진 타입에 맞게 채웠냐
+  const isTypeValid = () => {
+    // TODO 추후에 백엔드와 논의 후에 로직 넣어야함.
+    return true;
+  };
+
+  const validateInput = () => {
+    // 1 input 다 채워졌는지 검증  => isFilled()
+    // 2 input 타입 검증 => isTypeValid()
+    return isFilled() && isTypeValid() ? true : false;
   };
 
   const handleSave = () => {
+    if (!validateInput()) return;
     onSave(deepCopy(inputs));
+    console.log('저장된 testcase 정보는 :', inputs);
     modal.close();
   };
 
-  const handleChangeInput = (targetId: number, newParam: string) => {
-    const changedSimulation = inputs.find(({ id }) => id === targetId);
-    if (changedSimulation) {
-      changedSimulation.input = newParam;
+  const handleClickAddButton = () => {
+    if (inputs.length >= MAX_INPUT_COUNT) return;
+    setInputs((prev) => [
+      ...prev,
+      { id: prev.length + 1, input: '', expected: '', changable: true },
+    ]);
+  };
+
+  const handleChangeInput = ({ newInput, dataIndex, dataType }: InputChangeProps) => {
+    console.log(newInput, dataIndex, dataType);
+    const changedInput = inputs.find(({ id }) => id === dataIndex);
+    if (!changedInput) return;
+    const originInputs = deepCopy(inputs);
+    if (dataType === 'input') {
+      changedInput.input = newInput;
     }
-    setInputs([...inputs]);
+    if (dataType === 'expected') {
+      changedInput.expected = newInput;
+    }
+    originInputs[dataIndex - 1] = changedInput;
+    setInputs([...originInputs]);
+  };
+
+  const handleDeleteInput = (targetId: number) => {
+    const originInputs = deepCopy(inputs);
+    const targetIndex = originInputs.findIndex(({ id }) => id === targetId);
+    if (targetIndex === -1) return;
+    originInputs.splice(targetIndex, 1);
+    setInputs(originInputs.map((input, index) => ({ ...input, id: index + 1 })));
   };
 
   return (
     <Modal {...props}>
-      <SimulationInputList
-        inputList={inputs}
-        onChangeInput={handleChangeInput}
-      ></SimulationInputList>
-      <button onClick={handleCloseModal}>닫기</button>
-      <button onClick={handleSave}>저장</button>
+      <div className={cx(rowStyle, paddingStyle)}>
+        <header>테스트 케이스 추가</header>
+        <button onClick={handleCloseModal}>x</button>
+      </div>
+      <div className={cx(ListWrapperStyle, rowStyle)}>
+        <section>
+          <div className={rowStyle}>
+            <div>Parameters</div>
+            <button onClick={handleClickAddButton}>+추가</button>
+          </div>
+          <SimulationInputList
+            inputList={inputs}
+            onChangeInput={handleChangeInput}
+            onDeleteInput={handleDeleteInput}
+          ></SimulationInputList>
+        </section>
+      </div>
+      <div className={positionEndStyle}>
+        <button onClick={handleSave}>확인</button>
+      </div>
     </Modal>
   );
 }
+
+const ListWrapperStyle = css({
+  border: '1px solid silver',
+  padding: '1rem',
+  margin: '1rem',
+});
+
+const rowStyle = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+const paddingStyle = css({
+  padding: '4px',
+});
+
+const positionEndStyle = css({
+  display: 'flex',
+  flexDirection: 'row-reverse',
+});
+
+export { type InputChangeProps };

--- a/frontend/src/hooks/simulation/types.ts
+++ b/frontend/src/hooks/simulation/types.ts
@@ -1,6 +1,8 @@
 export type SimulationInput = {
   id: number;
   input: string;
+  expected?: string;
+  changable?: boolean;
 };
 
 export type SimulationResult = {

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -173,7 +173,7 @@ const problemTitleStyle = css({
 });
 
 const execButtonStyle = css({
-  color: 'black',
+  color: '#F5F5F5',
 });
 
 const rowStyle = css({


### PR DESCRIPTION
### 한 일

- 테스트 케이스 추가하는 모달에 확인, 닫기, 삭제 버튼(로직) 구현

- 확인 버튼
  -  인풋 검증 로직 체크 후 저장   
- 닫기 버튼
  -  모달 창 열기전 테스트 케이스 반영.
- 테스트 케이스 삭제
  - 그냥 삭제함

### 추가적으로 해야할 일

- 백엔드와 test case type에 대해서 논하고 타입 검증 로직 추가

### 화면

https://github.com/boostcampwm2023/web12-algo-with-me/assets/78193416/cc19012c-0e64-4078-9c12-6b46c0693c51

### 다른 버전
- 버튼에 css 먹여도 index.css에서 온 애가 이기더라구요. 나중에 css 정리해야겠습니다.

![스크린샷 2023-11-29 오후 11 43 57](https://github.com/boostcampwm2023/web12-algo-with-me/assets/78193416/4eadef51-2f61-4391-b225-8956f75b8a35)
