### PR TITLE
[#122] 대회 문제 조회 응답시 공개된 테스트케이스 값 보내주기

### DIFF
--- a/be/algo-with-me-api/src/competition/dto/competition.problem.response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.problem.response.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export type TestcaseParameterMetadata = { name: string; type: string };
+export type TestcaseData = { input: any[]; output: any };
+export interface ITestcases {
+  input: TestcaseParameterMetadata[];
+  output: TestcaseParameterMetadata;
+  data: TestcaseData[];
+}
+
 export class CompetitionProblemResponseDto {
   constructor(
     id: number,
@@ -8,7 +16,7 @@ export class CompetitionProblemResponseDto {
     memoryLimit: number,
     content: string,
     solutionCode: string,
-    testcases: object[],
+    testcases: ITestcases,
     createdAt: Date,
   ) {
     this.id = id;
@@ -40,7 +48,7 @@ export class CompetitionProblemResponseDto {
   solutionCode: string;
 
   @ApiProperty({ description: '공개 테스트 케이스' })
-  testcases: object[];
+  testcases: ITestcases;
 
   @ApiProperty()
   createdAt: Date;

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -11,11 +11,16 @@ import { Server } from 'socket.io';
 import { DataSource, Repository } from 'typeorm';
 
 import { existsSync, readFileSync } from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 
 import { ProblemService } from './problem.service';
 import { RESULT } from '../competition.enums';
-import { CompetitionProblemResponseDto } from '../dto/competition.problem.response.dto';
+import {
+  CompetitionProblemResponseDto,
+  ITestcases,
+  TestcaseData,
+} from '../dto/competition.problem.response.dto';
 import { CreateSubmissionDto } from '../dto/create-submission.dto';
 import { ProblemSimpleResponseDto } from '../dto/problem.simple.response.dto';
 import { ScoreResultDto } from '../dto/score-result.dto';
@@ -163,10 +168,43 @@ export class CompetitionService {
 
   async findOneProblem(id: number) {
     const problem = await this.problemRepository.findOneBy({ id });
+
     const fileName = id.toString() + '.md';
     const paths = path.join(process.env.PROBLEM_PATH, fileName);
     if (!existsSync(paths)) throw new NotFoundException('문제 파일을 찾을 수 없습니다.');
     const content = readFileSync(paths).toString();
+
+    const metadataPath = path.join(process.env.TESTCASE_PATH, problem.id.toString(), 'metadata');
+    let metadata;
+    if (!existsSync(metadataPath)) {
+      console.warn('문제에 대한 테스트케이스 메타데이터 파일을 찾을 수 없습니다.');
+      metadata = {
+        input: [],
+        output: null,
+        sampleTestcaseNum: 0,
+      };
+    } else {
+      metadata = JSON.parse(fs.readFileSync(metadataPath).toString());
+    }
+    const data: TestcaseData[] = [];
+    for (let i = 1; i <= metadata.sampleTestcaseNum; i++) {
+      const filename = path.join(
+        process.env.TESTCASE_PATH,
+        problem.id.toString(),
+        'samples',
+        i.toString(),
+      );
+      data.push({
+        input: JSON.parse(fs.readFileSync(`${filename}.in`).toString()),
+        output: JSON.parse(fs.readFileSync(`${filename}.ans`).toString()),
+      });
+    }
+    const testcases: ITestcases = {
+      input: metadata.input,
+      output: metadata.output,
+      data,
+    };
+
     return new CompetitionProblemResponseDto(
       problem.id,
       problem.title,
@@ -174,7 +212,7 @@ export class CompetitionService {
       problem.memoryLimit,
       content,
       problem.solutionCode,
-      [{ temp: '임시' }],
+      testcases,
       problem.createdAt,
     );
   }


### PR DESCRIPTION
https://www.notion.so/434b7c29f1f94f30b342f075843aa7e9

위 노션에 정리해둔 양식에 맞게 테스트케이스 값들을 보내줬습니다.
input, output 값을 JSON으로 변경하고 metadata 파일을 만들어줬기 때문에, 이제 프레임 코드 생성을 자동화할 수도 있습니다. 
배포 서버의 테스트케이스 파일, DB에 저장된 문제 프레임코드 변경해줬습니다.

`submissions/:problemId/metadata` 파일에 들어간 내용 예시

```json
{"input":[{"name":"times","type":"integer[][2]"}],"output":{"name":"maxMeetings","type":"integer"},"sampleTestcaseNum":1,"secretTestcaseNum":10}
```

예시: `/competitions/problems/1`

```json
{
    "id": 1,
    "title": "A+B",
    "timeLimit": 2000,
    "memoryLimit": 128000,
    "content": "# A+B\n\n### 제한\n\n- 시간 제한: 2초\n- 메모리 제한: 128MB\n\n### 문제\n\n두 정수 `a`와 `b`가 주어졌을 때, `a`와 `b`의 합을 반환하시오.\n\n### 조건\n\n- -10⁵ < `a` < 10⁵\n- -10⁵ < `b` < 10⁵\n\n",
    "solutionCode": "function solution(a, b) {\n  // a: 정수\n  // b: 정수\n  return 0;\n}",
    "testcases": {
        "input": [
            {
                "name": "a",
                "type": "integer"
            },
            {
                "name": "b",
                "type": "integer"
            }
        ],
        "output": {
            "name": "sum",
            "type": "integer"
        },
        "data": [
            {
                "input": [
                    1,
                    2
                ],
                "output": 3
            },
            {
                "input": [
                    -4,
                    -9
                ],
                "output": -13
            },
            {
                "input": [
                    0,
                    0
                ],
                "output": 0
            }
        ]
    },
    "createdAt": "2023-11-21T07:03:16.685Z"
}
```