### PR TITLE
[#186] websocket 검증로직 구현

### DIFF
--- a/be/algo-with-me-api/src/competition/competition.module.ts
+++ b/be/algo-with-me-api/src/competition/competition.module.ts
@@ -1,5 +1,5 @@
 import { BullModule } from '@nestjs/bull';
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CompetitionController } from './controllers/competition.controller';
@@ -33,9 +33,10 @@ import { UserModule } from '@src/user/user.module';
     }),
     AuthModule,
     UserModule,
-    DashboardModule,
+    forwardRef(() => DashboardModule),
   ],
   controllers: [ProblemController, CompetitionController],
   providers: [ProblemService, CompetitionService, CompetitionGateWay],
+  exports: [CompetitionService],
 })
 export class CompetitionModule {}

--- a/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
+++ b/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
@@ -101,10 +101,10 @@ export class CompetitionGateWay implements OnGatewayConnection, OnGatewayInit {
         authTokenPayloadDto.sub,
       );
       this.logger.debug(
-        `웹소켓 연결 성공, competition id: ${competitionId}, client id: ${client.id}, email: ${authTokenPayloadDto.sub}, args: ${args}`,
+        `competition 웹소켓 연결 성공, competition id: ${competitionId}, client id: ${client.id}, email: ${authTokenPayloadDto.sub}, args: ${args}`,
       );
     } catch (error) {
-      this.logger.debug(`웹소켓 연결 실패: ${error.message}`);
+      this.logger.debug(`competition 웹소켓 연결 실패: ${error.message}`);
       client.emit('message', { message: `${error.message}` });
       client.disconnect();
     }

--- a/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
+++ b/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
@@ -82,23 +82,27 @@ export class CompetitionGateWay implements OnGatewayConnection, OnGatewayInit {
       const user: User = await this.userService.getByEmail(authTokenPayloadDto.sub);
       await this.competitionService.isUserJoinedCompetition(Number(competitionId), user.id);
 
-      client.data['competitionId'] = Number(competitionId);
-      client.data['email'] = authTokenPayloadDto.sub;
-      
       // 동일한 유저의 다른 연결 끊기
       this.server.to(authTokenPayloadDto.sub).disconnectSockets();
 
+      // 만약 종료된 대회에 연결하려고 하면 끊기
+      await this.competitionService.isCompetitionFinished(Number(competitionId));
+
+      client.data['competitionId'] = Number(competitionId);
+      client.data['email'] = authTokenPayloadDto.sub;
       client.join(competitionId);
       client.join(authTokenPayloadDto.sub);
-      
-      this.dashboardService.registerUserAtCompetition(
+
+      await this.dashboardService.registerUserAtCompetition(
         Number(competitionId),
         authTokenPayloadDto.sub,
       );
-      this.logger.debug(client.id, client.handshake.auth);
-      this.logger.debug(competitionId, args);
+      this.logger.debug(
+        `웹소켓 연결 성공, competition id: ${competitionId}, client id: ${client.id}, email: ${authTokenPayloadDto.sub}, args: ${args}`,
+      );
     } catch (error) {
-      client.emit('errorMessage', { message: `${error.message}` });
+      this.logger.debug(`웹소켓 연결 실패: ${error.message}`);
+      client.emit('message', { message: `${error.message}` });
       client.disconnect();
     }
   }

--- a/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
+++ b/be/algo-with-me-api/src/competition/gateways/competition.gateway.ts
@@ -46,7 +46,7 @@ export class CompetitionGateWay implements OnGatewayConnection, OnGatewayInit {
     @ConnectedSocket() client: Socket,
   ) {
     try {
-      await this.competitionService.isCompetitionFinished(client.data['competitionId']);
+      await this.competitionService.isCompetitionOngoing(client.data['competitionId']);
       const user: User = await this.userService.getByEmail(client.data['email']);
       const testcaseNum: number = await this.problemService.getProblemTestcaseNum(
         createSubmissionDto.problemId,

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -341,6 +341,18 @@ export class CompetitionService {
       throw new BadRequestException(`${competitionId}는 이미 종료된 대회입니다.`);
   }
 
+  async isCompetitionOngoing(competitionId: number) {
+    const competition: Competition = await this.competitionRepository.findOneBy({
+      id: competitionId,
+    });
+    this.assertCompetitionExists(competition);
+    const time: Date = new Date();
+    if (time.getTime() - competition.endsAt.getTime() > 0)
+      throw new BadRequestException(`${competitionId}는 이미 종료된 대회입니다.`);
+    if (competition.startsAt.getTime() - time.getTime() > 0)
+      throw new BadRequestException(`${competitionId}는 아직 시작하지 않은 대회입니다.`);
+  }
+
   private assertCompetitionExists(competition: Competition) {
     if (!competition)
       throw new NotFoundException(

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -331,6 +331,16 @@ export class CompetitionService {
       return new ProblemSimpleResponseDto(element.problem.id, element.problem.title);
     });
   }
+
+  async isCompetitionFinished(competitionId: number) {
+    const competition: Competition = await this.competitionRepository.findOneBy({
+      id: competitionId,
+    });
+    this.assertCompetitionExists(competition);
+    if (new Date().getTime() - competition.endsAt.getTime() > 0)
+      throw new BadRequestException(`${competitionId}는 이미 종료된 대회입니다.`);
+  }
+
   private assertCompetitionExists(competition: Competition) {
     if (!competition)
       throw new NotFoundException(

--- a/be/algo-with-me-api/src/dashboard/dashboard.module.ts
+++ b/be/algo-with-me-api/src/dashboard/dashboard.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DashboardController } from './dashboard.controller';
@@ -13,7 +13,7 @@ import { CompetitionProblem } from '@src/competition/entities/competition.proble
 @Module({
   imports: [
     TypeOrmModule.forFeature([Dashboard, CompetitionProblem, Competition]),
-    CompetitionModule,
+    forwardRef(() => CompetitionModule),
   ],
   providers: [DashboardGateway, DashboardService],
   controllers: [DashboardController],

--- a/be/algo-with-me-api/src/dashboard/dashboard.module.ts
+++ b/be/algo-with-me-api/src/dashboard/dashboard.module.ts
@@ -6,11 +6,15 @@ import { DashboardGateway } from './dashboard.gateway';
 import { DashboardService } from './dashboard.service';
 import { Dashboard } from './entities/dashboard.entity';
 
+import { CompetitionModule } from '@src/competition/competition.module';
 import { Competition } from '@src/competition/entities/competition.entity';
 import { CompetitionProblem } from '@src/competition/entities/competition.problem.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Dashboard, CompetitionProblem, Competition])],
+  imports: [
+    TypeOrmModule.forFeature([Dashboard, CompetitionProblem, Competition]),
+    CompetitionModule,
+  ],
   providers: [DashboardGateway, DashboardService],
   controllers: [DashboardController],
   exports: [DashboardService],

--- a/be/algo-with-me-api/src/user/services/user.service.ts
+++ b/be/algo-with-me-api/src/user/services/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -23,6 +23,7 @@ export class UserService {
 
   async getByEmail(email: string) {
     const user = await this.userRepository.findOneBy({ email });
+    if (!user) throw new NotFoundException(`${email} 에 해당하는 유저를 찾을 수 없습니다.`);
     return user;
   }
 }


### PR DESCRIPTION
competition websocket 첫 연결시 검증
- 유저가 대회에 참여중인지 확인
- 동일한 유저의 다른 연결이 있을 경우 이전의 연결을 모두 끊음
- 이미 종료된 대회일 경우 연결을 끊음

competition websocket 제출 검증
- 대회시간 범위 안이 맞는지 확인, 아닐 경우 연결 끊음
클라이언트 유저 정보를 메모리(`client.data`)에 저장할지, 제출할 때 마다 db에서 가져올지 고민했습니다.
둘이 눈에 띌 만큼 큰 차이는 없다고 생각해서 db에서 가져오도록 했습니다. 추후 속도가 느려진다고 판단되면 메모리 저장으로 변경하겠습니다.

dashboard websocket 첫 연결시 검증
- 대회가 존재하는지, 대회 종료시간 이전인지 확인

## 참고
https://www.notion.so/websocket-a122aa7e7ad64fac94f82b5ba9403551?pvs=4
