### PR TITLE
[#199] 대시보드 화면 처리

### DIFF
--- a/frontend/src/components/Dashboard/DashboardLoading.tsx
+++ b/frontend/src/components/Dashboard/DashboardLoading.tsx
@@ -1,0 +1,32 @@
+import { css } from '@style/css';
+
+import { Text } from '../Common';
+
+export default function DashboardLoading() {
+  return (
+    <div className={pageStyle}>
+      <Text type="display">대회 종료 후 5분 뒤에 집계가 완료됩니다</Text>
+      <div className={loadingIconStyle}></div>
+    </div>
+  );
+}
+
+const pageStyle = css({
+  minHeight: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: 'var(--Background, #263238)',
+  color: '#fff',
+});
+
+const loadingIconStyle = css({
+  width: '50px',
+  height: '50px',
+  border: '8px solid #fff',
+  borderTop: '8px solid transparent',
+  borderRadius: '50%',
+  animation: 'spin 1s linear infinite',
+  marginTop: '20px',
+});

--- a/frontend/src/components/Dashboard/DashboardModal.tsx
+++ b/frontend/src/components/Dashboard/DashboardModal.tsx
@@ -1,5 +1,8 @@
 import { css } from '@style/css';
 
+import { useParticipantDashboardSocket } from '@/hooks/dashboard';
+import { range } from '@/utils/array';
+
 import { Button } from '../Common';
 import DashboardTable from './DashboardTable';
 
@@ -9,6 +12,9 @@ interface Props {
 }
 
 export default function DashboardModal({ isOpen, onClose }: Props) {
+  const { ranks, totalProblemCount, myRank } = useParticipantDashboardSocket();
+  const problemCount = range(1, totalProblemCount + 1);
+
   if (!isOpen) {
     return null;
   }
@@ -16,7 +22,7 @@ export default function DashboardModal({ isOpen, onClose }: Props) {
   return (
     <div className={modalOverlayStyle} onClick={onClose}>
       <div className={modalContentStyle} onClick={(e) => e.stopPropagation()}>
-        <DashboardTable />
+        <DashboardTable ranks={ranks} myRank={myRank} problemCount={problemCount} />
         <Button onClick={onClose}>닫기</Button>
       </div>
     </div>

--- a/frontend/src/components/Dashboard/DashboardTable.tsx
+++ b/frontend/src/components/Dashboard/DashboardTable.tsx
@@ -1,13 +1,15 @@
 import { css } from '@style/css';
 
-import { useParticipantDashboard } from '@/hooks/dashboard';
-import { range } from '@/utils/array';
+import type { Rank } from '@/hooks/dashboard/types';
 import { isNil } from '@/utils/type';
 
-export default function DashboardTable() {
-  const { ranks, totalProblemCount, myRank } = useParticipantDashboard();
-  const problemCount = range(1, totalProblemCount + 1);
+interface Props {
+  ranks: Rank[];
+  myRank: Rank | null;
+  problemCount: number[];
+}
 
+export default function DashboardTable({ ranks, myRank, problemCount }: Props) {
   return (
     <table className={tableStyle}>
       <thead>

--- a/frontend/src/components/Dashboard/DashboardTableApi.tsx
+++ b/frontend/src/components/Dashboard/DashboardTableApi.tsx
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+
+import { useParticipantDashboardApi } from '@/hooks/dashboard';
+import { range } from '@/utils/array';
+
+import AuthContext from '../Auth/AuthContext';
+import DashboardTable from './DashboardTable';
+
+interface Props {
+  competitionId: number;
+}
+
+export default function DashboardTableApi({ competitionId }: Props) {
+  const { email } = useContext(AuthContext);
+  const { ranks, totalProblemCount, myRank } = useParticipantDashboardApi(competitionId, email);
+  const problemCount = range(1, totalProblemCount + 1);
+  console.log(email);
+
+  return <DashboardTable ranks={ranks} myRank={myRank} problemCount={problemCount} />;
+}

--- a/frontend/src/components/Dashboard/DashboardTableApi.tsx
+++ b/frontend/src/components/Dashboard/DashboardTableApi.tsx
@@ -14,7 +14,6 @@ export default function DashboardTableApi({ competitionId }: Props) {
   const { email } = useContext(AuthContext);
   const { ranks, totalProblemCount, myRank } = useParticipantDashboardApi(competitionId, email);
   const problemCount = range(1, totalProblemCount + 1);
-  console.log(email);
 
   return <DashboardTable ranks={ranks} myRank={myRank} problemCount={problemCount} />;
 }

--- a/frontend/src/components/Dashboard/DashboardTableSocket.tsx
+++ b/frontend/src/components/Dashboard/DashboardTableSocket.tsx
@@ -1,0 +1,11 @@
+import { useParticipantDashboardSocket } from '@/hooks/dashboard';
+import { range } from '@/utils/array';
+
+import DashboardTable from './DashboardTable';
+
+export default function DashboardTableSocket() {
+  const { ranks, totalProblemCount, myRank } = useParticipantDashboardSocket();
+  const problemCount = range(1, totalProblemCount + 1);
+
+  return <DashboardTable ranks={ranks} myRank={myRank} problemCount={problemCount} />;
+}

--- a/frontend/src/hooks/dashboard/index.ts
+++ b/frontend/src/hooks/dashboard/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
-export * from './useParticipantDashboard';
+export * from './useParticipantDashboardsocket';
+export * from './useParticipantDashboardApi';

--- a/frontend/src/hooks/dashboard/useParticipantDashboardApi.ts
+++ b/frontend/src/hooks/dashboard/useParticipantDashboardApi.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import api from '@/utils/api';
+
+import type { Dashboard, Rank } from './types';
+
+export function useParticipantDashboardApi(competitionId: number, email: string) {
+  const [ranks, setRanks] = useState<Rank[]>([]);
+  const [myRank, setMyRank] = useState<Rank>({
+    rank: 0,
+    email: '',
+    score: 0,
+    problemDict: {},
+  });
+  const [totalProblemCount, setTotalProblemCount] = useState(-1);
+
+  const fetchData = async () => {
+    try {
+      const response = await api.get(`/dashboards/${competitionId}`, {
+        params: {
+          email,
+        },
+      });
+
+      const newDashboard: Dashboard = response.data;
+
+      setRanks(newDashboard.rankings);
+      setMyRank(newDashboard.myRanking);
+      setTotalProblemCount(newDashboard.totalProblemCount);
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [competitionId, email]);
+
+  return {
+    ranks,
+    myRank,
+    totalProblemCount,
+  };
+}

--- a/frontend/src/hooks/dashboard/useParticipantDashboardSocket.ts
+++ b/frontend/src/hooks/dashboard/useParticipantDashboardSocket.ts
@@ -7,7 +7,7 @@ import type { Dashboard, Rank } from './types';
 
 const INTERVAL_TIME = 5000;
 
-export function useParticipantDashboard() {
+export function useParticipantDashboardSocket() {
   const { socket } = useContext(SocketContext);
   const [ranks, setRanks] = useState<Rank[]>([]);
   const [myRank, setMyRank] = useState<Rank>({

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { css } from '@style/css';
 import { useParams } from 'react-router-dom';
 
 import { SocketProvider } from '@/components/Common/Socket/SocketProvider';
+import DashboardLoading from '@/components/Dashboard/DashboardLoading';
 import DashboardTable from '@/components/Dashboard/DashboardTable';
 import Header from '@/components/Header';
 import { useCompetition } from '@/hooks/competition';
@@ -18,6 +19,13 @@ export default function DashboardPage() {
   let competitionStatusText = '대회 전';
   if (currentTime >= new Date(startsAt)) {
     competitionStatusText = currentTime <= new Date(endsAt) ? '진행 중' : '대회 종료';
+  }
+
+  const fiveMinutesAfterEnd = new Date(endsAt);
+  fiveMinutesAfterEnd.setMinutes(fiveMinutesAfterEnd.getMinutes() + 5);
+
+  if (currentTime < fiveMinutesAfterEnd && currentTime >= new Date(endsAt)) {
+    return <DashboardLoading />;
   }
 
   return (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,7 +4,8 @@ import { useParams } from 'react-router-dom';
 
 import { SocketProvider } from '@/components/Common/Socket/SocketProvider';
 import DashboardLoading from '@/components/Dashboard/DashboardLoading';
-import DashboardTable from '@/components/Dashboard/DashboardTable';
+import DashboardTableApi from '@/components/Dashboard/DashboardTableApi';
+import DashboardTableSocket from '@/components/Dashboard/DashboardTableSocket';
 import Header from '@/components/Header';
 import { useCompetition } from '@/hooks/competition';
 
@@ -41,7 +42,11 @@ export default function DashboardPage() {
           <span className={competitionTitleStyle}>{competition.name}</span>
           <span>{competitionStatusText}</span>
         </section>
-        <DashboardTable />
+        {currentTime < fiveMinutesAfterEnd ? (
+          <DashboardTableSocket />
+        ) : (
+          <DashboardTableApi competitionId={competitionId} />
+        )}
       </SocketProvider>
     </main>
   );


### PR DESCRIPTION
### 한 일
- 대회 종료 후 5분동안 집계 화면을 보여주고, 5분 뒤부터는 http request로 받은 데이터를 사용해 대시보드를 출력합니다.

### 스크린샷

- 대회 종료 전

![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/3044514e-87a7-436e-9c7e-97c2f47a2558)


- 대회 종료 5분 후

![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/1ba50847-9f83-493f-87f2-16f9f2487993)
