### PR TITLE
[#175] 대회 페이지 레이아웃 개선

### DIFF
--- a/frontend/panda.config.ts
+++ b/frontend/panda.config.ts
@@ -66,5 +66,10 @@ export default defineConfig({
         },
       },
     },
+    tokens: {
+      animations: {
+        spin: { value: 'spin 1s linear infinite' },
+      },
+    },
   },
 });

--- a/frontend/src/components/Auth/AuthContext.ts
+++ b/frontend/src/components/Auth/AuthContext.ts
@@ -3,8 +3,9 @@ import { createContext } from 'react';
 const AuthContext = createContext({
   isLoggedin: false,
   email: '',
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  login: (email: string) => {},
+  login: (email: string) => {
+    email;
+  },
   logout: () => {},
 });
 

--- a/frontend/src/components/Common/BreadCrumb.tsx
+++ b/frontend/src/components/Common/BreadCrumb.tsx
@@ -12,19 +12,26 @@ export default function BreadCrumb({ crumbs, className, ...props }: Props) {
   const lastIndex = crumbs.length - 1;
 
   return (
-    <VStack as="nav" className={cx(className, style)} {...props}>
-      {crumbs.map((crumb, index) => (
-        <>
-          <Text.Body key={index} bold>
-            {crumb}
-          </Text.Body>
-          {index !== lastIndex ? <Icon.ChevronRight size={24}></Icon.ChevronRight> : null}
-        </>
-      ))}
-    </VStack>
+    <nav>
+      <VStack className={cx(className, style)} {...props}>
+        {crumbs.map((crumb, index) => (
+          <div className={crumbStyle} key={index}>
+            <Text.Body bold>{crumb}</Text.Body>
+            {index !== lastIndex ? <Icon.ChevronRight size={24} /> : null}
+          </div>
+        ))}
+      </VStack>
+    </nav>
   );
 }
 
 const style = css({
   gap: '0.25rem',
+});
+
+const crumbStyle = css({
+  display: 'flex',
+  placeItems: 'center',
+  marginY: 'auto',
+  marginX: '0',
 });

--- a/frontend/src/components/Common/BreadCrumb.tsx
+++ b/frontend/src/components/Common/BreadCrumb.tsx
@@ -8,7 +8,7 @@ interface Props extends HTMLAttributes<HTMLElement> {
   crumbs: string[];
 }
 
-export default function BreadCrumb({ crumbs, className, ...props }: Props) {
+export function BreadCrumb({ crumbs, className, ...props }: Props) {
   const lastIndex = crumbs.length - 1;
 
   return (

--- a/frontend/src/components/Common/BreadCrumb.tsx
+++ b/frontend/src/components/Common/BreadCrumb.tsx
@@ -2,33 +2,29 @@ import { css, cx } from '@style/css';
 
 import { HTMLAttributes } from 'react';
 
+import { Icon, Text, VStack } from '.';
+
 interface Props extends HTMLAttributes<HTMLElement> {
   crumbs: string[];
 }
 
 export default function BreadCrumb({ crumbs, className, ...props }: Props) {
+  const lastIndex = crumbs.length - 1;
+
   return (
-    <nav className={cx(className, crumbStyle)} {...props}>
+    <VStack as="nav" className={cx(className, style)} {...props}>
       {crumbs.map((crumb, index) => (
-        <span key={index} className={crumbStyle}>
-          {crumb}
-        </span>
+        <>
+          <Text.Body key={index} bold>
+            {crumb}
+          </Text.Body>
+          {index !== lastIndex ? <Icon.ChevronRight size={24}></Icon.ChevronRight> : null}
+        </>
       ))}
-    </nav>
+    </VStack>
   );
 }
 
-const crumbStyle = css({
-  fontWeight: 'bold',
-  color: 'text.week',
-  marginRight: '1rem',
-  _after: {
-    content: '">"',
-    marginLeft: '1rem',
-  },
-  _last: {
-    _after: {
-      content: '""',
-    },
-  },
+const style = css({
+  gap: '0.25rem',
 });

--- a/frontend/src/components/Common/HStack/HStack.tsx
+++ b/frontend/src/components/Common/HStack/HStack.tsx
@@ -18,5 +18,6 @@ export function HStack({ children, className, as = 'div', ...props }: Props) {
 
 const rowListStyle = css({
   display: 'flex',
+  placeItems: 'center',
   flexDirection: 'column',
 });

--- a/frontend/src/components/Common/HStack/HStack.tsx
+++ b/frontend/src/components/Common/HStack/HStack.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@style/css';
 
 import { HTMLAttributes } from 'react';
 
-interface Props extends HTMLAttributes<HTMLElement> {
+export interface Props extends HTMLAttributes<HTMLElement> {
   as?: React.ElementType;
 }
 

--- a/frontend/src/components/Common/HStack/HStack.tsx
+++ b/frontend/src/components/Common/HStack/HStack.tsx
@@ -18,6 +18,5 @@ export function HStack({ children, className, as = 'div', ...props }: Props) {
 
 const rowListStyle = css({
   display: 'flex',
-  placeItems: 'center',
   flexDirection: 'column',
 });

--- a/frontend/src/components/Common/HStack/index.ts
+++ b/frontend/src/components/Common/HStack/index.ts
@@ -1,0 +1,1 @@
+export { HStack } from './HStack';

--- a/frontend/src/components/Common/HStack/index.ts
+++ b/frontend/src/components/Common/HStack/index.ts
@@ -1,1 +1,2 @@
 export { HStack } from './HStack';
+export type { Props as HStackProps } from './HStack';

--- a/frontend/src/components/Common/Icon.tsx
+++ b/frontend/src/components/Common/Icon.tsx
@@ -10,14 +10,25 @@ type IconName = 'chevron-right' | 'check-round' | 'cancel-round' | 'spinner' | '
 interface Props extends HTMLAttributes<HTMLSpanElement> {
   size?: number;
   color?: Theme;
+  spin?: boolean;
   name: IconName;
 }
 
-export function Icon({ className, size = 24, name = 'cancel', color = 'info', ...props }: Props) {
+export function Icon({
+  className,
+  size = 24,
+  name = 'cancel',
+  color = 'info',
+  spin = false,
+  ...props
+}: Props) {
   const iconPath = `${icons}#${name}`;
 
   return (
-    <span className={cx(className, style, themeStyle({ color }))} {...props}>
+    <span
+      className={cx(className, style, themeStyle({ color }), animationStyle({ spin }))}
+      {...props}
+    >
       <svg width={size} height={size} fill={color}>
         <use href={iconPath}></use>
       </svg>
@@ -55,6 +66,17 @@ const themeStyle = cva({
       },
       info: {
         fill: 'alert.info',
+      },
+    },
+  },
+});
+
+const animationStyle = cva({
+  variants: {
+    spin: {
+      true: {
+        transformOrigin: 'center',
+        animation: 'spin',
       },
     },
   },

--- a/frontend/src/components/Common/Logo.tsx
+++ b/frontend/src/components/Common/Logo.tsx
@@ -4,7 +4,7 @@ interface Props {
   size: number | `${string}px`;
 }
 
-export default function Logo({ size }: Props) {
+export function Logo({ size }: Props) {
   const logoSize = isNumber(size) ? `${size}px` : size;
 
   return <img src="/algo.png" alt="logo" width={logoSize} height={logoSize} />;

--- a/frontend/src/components/Common/Logo.tsx
+++ b/frontend/src/components/Common/Logo.tsx
@@ -1,7 +1,11 @@
+import { isNumber } from '@/utils/type';
+
 interface Props {
-  size: string;
+  size: number | `${string}px`;
 }
 
 export default function Logo({ size }: Props) {
-  return <img src="/algo.png" alt="logo" width={size} height={size} />;
+  const logoSize = isNumber(size) ? `${size}px` : size;
+
+  return <img src="/algo.png" alt="logo" width={logoSize} height={logoSize} />;
 }

--- a/frontend/src/components/Common/VStack/VStack.tsx
+++ b/frontend/src/components/Common/VStack/VStack.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@style/css';
 
 import { HTMLAttributes } from 'react';
 
-interface Props extends HTMLAttributes<HTMLElement> {
+export interface Props extends HTMLAttributes<HTMLElement> {
   as?: React.ElementType;
 }
 

--- a/frontend/src/components/Common/VStack/VStack.tsx
+++ b/frontend/src/components/Common/VStack/VStack.tsx
@@ -18,5 +18,4 @@ export function VStack({ children, className, as = 'div', ...props }: Props) {
 
 const rowListStyle = css({
   display: 'flex',
-  placeItems: 'center',
 });

--- a/frontend/src/components/Common/VStack/VStack.tsx
+++ b/frontend/src/components/Common/VStack/VStack.tsx
@@ -18,4 +18,5 @@ export function VStack({ children, className, as = 'div', ...props }: Props) {
 
 const rowListStyle = css({
   display: 'flex',
+  placeItems: 'center',
 });

--- a/frontend/src/components/Common/VStack/index.ts
+++ b/frontend/src/components/Common/VStack/index.ts
@@ -1,0 +1,2 @@
+export { VStack } from './VStack';
+export type { Props as VStackProps } from './VStack';

--- a/frontend/src/components/Common/index.ts
+++ b/frontend/src/components/Common/index.ts
@@ -8,3 +8,5 @@ export * from './Text';
 export * from './Link';
 export * from './Chip';
 export * from './Icon';
+export * from './BreadCrumb';
+export * from './Logo';

--- a/frontend/src/components/Competition/CompetitionHeader.tsx
+++ b/frontend/src/components/Competition/CompetitionHeader.tsx
@@ -18,4 +18,5 @@ const headerStyle = css({
   borderBottom: '1px solid',
   borderColor: 'border',
   gap: '1rem',
+  placeItems: 'center',
 });

--- a/frontend/src/components/Competition/CompetitionHeader.tsx
+++ b/frontend/src/components/Competition/CompetitionHeader.tsx
@@ -1,21 +1,21 @@
 import { css, cx } from '@style/css';
 
-import { type HTMLAttributes } from 'react';
+import { VStack, type VStackProps } from '../Common';
 
-interface Props extends HTMLAttributes<HTMLDivElement> {}
+interface Props extends VStackProps {}
 
 export default function CompetitionHeader({ className, children, ...props }: Props) {
   return (
-    <div className={cx(className, headerStyle)} {...props}>
+    <VStack className={cx(className, headerStyle)} as="header" {...props}>
       {children}
-    </div>
+    </VStack>
   );
 }
 
 const headerStyle = css({
-  height: '3.125rem',
-  display: 'flex',
-  justifyContent: 'space-between',
+  height: '4rem',
+  paddingY: '0.5rem',
   borderBottom: '1px solid',
   borderColor: 'border',
+  gap: '1rem',
 });

--- a/frontend/src/components/Competition/CompetitionProblemSelector.tsx
+++ b/frontend/src/components/Competition/CompetitionProblemSelector.tsx
@@ -1,36 +1,50 @@
 import { css } from '@style/css';
 
-import { Button } from '../Common';
+import { HTMLAttributes } from 'react';
 
-interface AsideProps {
+import { Button, HStack } from '../Common';
+
+interface Props extends HTMLAttributes<HTMLMenuElement> {
   problemIds: number[];
+  currentIndex: number;
   onChangeProblemIndex: (index: number) => void;
 }
 
-export default function CompetitionProblemSelector(props: AsideProps) {
+export default function CompetitionProblemSelector({
+  problemIds,
+  currentIndex,
+  onChangeProblemIndex,
+  ...props
+}: Props) {
   function handleChangeProblemIndex(index: number) {
-    props.onChangeProblemIndex(index);
+    onChangeProblemIndex(index);
   }
 
   return (
-    <ul className={listStyle}>
-      {props.problemIds.map((id: number, index: number) => (
+    <HStack as="menu" className={listStyle} {...props}>
+      {problemIds.map((id: number, index: number) => (
         <li key={id}>
-          <Button className={selectProblemStyle} onClick={() => handleChangeProblemIndex(index)}>
-            문제{index + 1}
+          <Button
+            className={buttonStyle}
+            selected={currentIndex === index}
+            onClick={() => handleChangeProblemIndex(index)}
+          >
+            {index + 1}
           </Button>
         </li>
       ))}
-    </ul>
+    </HStack>
   );
 }
 
 const listStyle = css({
+  listStyle: 'none',
   display: 'flex',
   flexDirection: 'column',
-  gap: '0.5rem',
+  gap: '1rem',
 });
 
-const selectProblemStyle = css({
-  color: 'black',
+const buttonStyle = css({
+  width: '3rem',
+  height: '3rem',
 });

--- a/frontend/src/components/Competition/CompetitionProblemSelector.tsx
+++ b/frontend/src/components/Competition/CompetitionProblemSelector.tsx
@@ -42,6 +42,7 @@ const listStyle = css({
   display: 'flex',
   flexDirection: 'column',
   gap: '1rem',
+  placeItems: 'center',
 });
 
 const buttonStyle = css({

--- a/frontend/src/components/Editor/Editor.tsx
+++ b/frontend/src/components/Editor/Editor.tsx
@@ -12,9 +12,9 @@ interface Props {
 const Editor = (props: Props) => {
   return (
     <CodeMirror
+      style={{ height: props.height, width: props.width }}
       value={props.code}
-      height={props.height ?? '100%'}
-      width={props.width ?? '100%'}
+      height={'100%'}
       theme={vscodeDark}
       extensions={[javascript()]}
       initialState={undefined}

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@style/css';
 
-import Logo from '@/components/Common/Logo';
+import { Logo } from '@/components/Common';
 import useAuth from '@/hooks/login/useAuth';
 
 export default function Header() {

--- a/frontend/src/components/Problem/ProblemHeader.tsx
+++ b/frontend/src/components/Problem/ProblemHeader.tsx
@@ -3,34 +3,33 @@ import { css, cx } from '@style/css';
 import { HTMLAttributes } from 'react';
 
 import type { ProblemInfo } from '@/apis/problems';
+import { Text } from '@/components/Common';
 
-interface Props extends HTMLAttributes<HTMLElement> {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   problem: ProblemInfo;
 }
+
 export function ProblemHeader({ problem, className, ...props }: Props) {
   return (
-    <section className={cx(rowListStyle, spaceBetweenStyle, underlineStyle, className)} {...props}>
-      <span className={problemTitleStyle}>{problem.title}</span>
-    </section>
+    <div className={cx(className, style)} {...props}>
+      <Text.Title className={problemTitleStyle} size="lg" bold>
+        {problem.title}
+      </Text.Title>
+    </div>
   );
 }
 
-const rowListStyle = css({
-  display: 'flex',
-});
-
-const underlineStyle = css({
+const style = css({
   borderBottom: '1px solid',
   borderColor: 'border',
 });
 
-const spaceBetweenStyle = css({
-  justifyContent: 'space-between',
-});
-
 const problemTitleStyle = css({
   display: 'inline-block',
-  padding: '10px',
+  paddingY: '1rem',
+  paddingX: '1.25rem',
+  marginLeft: '4rem',
+  color: 'brand',
   borderBottom: '2px solid',
   borderColor: 'brand',
 });

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -1,12 +1,13 @@
 import { css } from '@style/css';
 
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { CompetitionId } from '@/apis/competitions';
 import { CompetitionProblem } from '@/apis/problems';
 import { useUserCode } from '@/hooks/editor/useUserCode';
 import useAuth from '@/hooks/login/useAuth';
 import { SimulationInput, useSimulation } from '@/hooks/simulation';
+import * as customLocalStorage from '@/utils/localStorage';
 
 import { Button, HStack, HStackProps, Modal, Space, VStack } from '../Common';
 import Editor from '../Editor/Editor';
@@ -18,13 +19,17 @@ import { SubmissionResult } from '../Submission/SubmissionResult';
 import ProblemViewer from './ProblemViewer';
 
 interface Props extends HStackProps {
+  currentProblemIndex: number;
   competitionId: CompetitionId;
   problem: CompetitionProblem;
 }
 
-export function ProblemSolveContainer({ competitionId, problem, ...props }: Props) {
-  const simulation = useSimulation(problem.testcases);
-
+export function ProblemSolveContainer({
+  currentProblemIndex,
+  competitionId,
+  problem,
+  ...props
+}: Props) {
   const { email } = useAuth();
   const { code, setCode } = useUserCode({
     userId: email,
@@ -34,12 +39,8 @@ export function ProblemSolveContainer({ competitionId, problem, ...props }: Prop
     save: customLocalStorage.save,
   });
 
-  const handleChangeCode = (newCode: string) => {
-    setCode(newCode);
-  };
-  useEffect(() => {
-    setCode(problem.solutionCode);
-  }, [problem.solutionCode]);
+  const simulation = useSimulation(problem.testcases);
+
   const handleChangeCode = (newCode: string) => {
     setCode(newCode);
   };
@@ -51,15 +52,20 @@ export function ProblemSolveContainer({ competitionId, problem, ...props }: Prop
   const handleSimulationCancel = () => {
     simulation.cancel();
   };
-  const modal = useContext(Modal.Context);
 
   const handleSaveSimulationInputs = (simulationInputs: SimulationInput[]) => {
     simulation.changeInputs(simulationInputs);
   };
 
+  const modal = useContext(Modal.Context);
+
   function handleOpenModal() {
     modal.open();
   }
+
+  useEffect(() => {
+    setCode(problem.solutionCode);
+  }, [problem.solutionCode, setCode]);
 
   return (
     <HStack className={css({ height: '100%' })} {...props}>
@@ -122,5 +128,5 @@ const footerStyle = css({
   paddingX: '1rem',
   gap: '0.5rem',
   borderTop: '1px solid',
-  border: 'border',
+  borderColor: 'border',
 });

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -1,6 +1,6 @@
 import { css } from '@style/css';
 
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 
 import { CompetitionId } from '@/apis/competitions';
 import { CompetitionProblem } from '@/apis/problems';

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -113,18 +113,19 @@ const problemSolveContainerStyle = css({
 
 const problemStyle = css({
   width: '1/2',
-  height: '100%',
+  height: 'full',
 });
+
 const solutionStyle = css({
   width: '1/2',
-  height: '100%',
+  height: 'full',
   alignItems: 'stretch',
   overflow: 'auto',
 });
 
 const footerStyle = css({
   height: '4rem',
-  width: '100%',
+  width: 'full',
   paddingX: '1rem',
   gap: '0.5rem',
   borderTop: '1px solid',

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -1,0 +1,126 @@
+import { css } from '@style/css';
+
+import { useContext, useEffect, useState } from 'react';
+
+import { CompetitionId } from '@/apis/competitions';
+import { CompetitionProblem } from '@/apis/problems';
+import { useUserCode } from '@/hooks/editor/useUserCode';
+import useAuth from '@/hooks/login/useAuth';
+import { SimulationInput, useSimulation } from '@/hooks/simulation';
+
+import { Button, HStack, HStackProps, Modal, Space, VStack } from '../Common';
+import Editor from '../Editor/Editor';
+import { SimulationExecButton } from '../Simulation/SimulationExecButton';
+import { SimulationInputModal } from '../Simulation/SimulationInputModal';
+import { SimulationResultList } from '../Simulation/SimulationResultList';
+import { SubmissionButton } from '../Submission/SubmissionButton';
+import { SubmissionResult } from '../Submission/SubmissionResult';
+import ProblemViewer from './ProblemViewer';
+
+interface Props extends HStackProps {
+  competitionId: CompetitionId;
+  problem: CompetitionProblem;
+}
+
+export function ProblemSolveContainer({ competitionId, problem, ...props }: Props) {
+  const simulation = useSimulation(problem.testcases);
+
+  const { email } = useAuth();
+  const { code, setCode } = useUserCode({
+    userId: email,
+    problem,
+    competitionId,
+    currentProblemIndex,
+    save: customLocalStorage.save,
+  });
+
+  const handleChangeCode = (newCode: string) => {
+    setCode(newCode);
+  };
+  useEffect(() => {
+    setCode(problem.solutionCode);
+  }, [problem.solutionCode]);
+  const handleChangeCode = (newCode: string) => {
+    setCode(newCode);
+  };
+
+  const handleSimulate = () => {
+    simulation.run(code);
+  };
+
+  const handleSimulationCancel = () => {
+    simulation.cancel();
+  };
+  const modal = useContext(Modal.Context);
+
+  const handleSaveSimulationInputs = (simulationInputs: SimulationInput[]) => {
+    simulation.changeInputs(simulationInputs);
+  };
+
+  function handleOpenModal() {
+    modal.open();
+  }
+
+  return (
+    <HStack className={css({ height: '100%' })} {...props}>
+      <VStack className={problemSolveContainerStyle}>
+        <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
+        <HStack className={solutionStyle}>
+          <Editor
+            height="500px"
+            width="100%"
+            code={problem.solutionCode}
+            onChangeCode={handleChangeCode}
+          ></Editor>
+          <section>
+            <SimulationResultList resultList={simulation.results}></SimulationResultList>
+            <SubmissionResult></SubmissionResult>
+          </section>
+        </HStack>
+      </VStack>
+      <VStack as="footer" className={footerStyle}>
+        <Button onClick={handleOpenModal}>테스트 케이스 추가하기</Button>
+        <Space></Space>
+        <SimulationExecButton
+          isRunning={simulation.isRunning}
+          onExec={handleSimulate}
+          onCancel={handleSimulationCancel}
+        />
+        <SubmissionButton
+          code={code}
+          problemId={problem.id}
+          competitionId={competitionId}
+        ></SubmissionButton>
+      </VStack>
+      <SimulationInputModal
+        simulationInputs={simulation.inputs}
+        onSave={handleSaveSimulationInputs}
+      ></SimulationInputModal>
+    </HStack>
+  );
+}
+
+const problemSolveContainerStyle = css({
+  height: 'calc(100% - 4rem)',
+  width: 'full',
+});
+
+const problemStyle = css({
+  width: '1/2',
+  height: '100%',
+});
+const solutionStyle = css({
+  width: '1/2',
+  height: '100%',
+  alignItems: 'stretch',
+  overflow: 'auto',
+});
+
+const footerStyle = css({
+  height: '4rem',
+  width: '100%',
+  paddingX: '1rem',
+  gap: '0.5rem',
+  borderTop: '1px solid',
+  border: 'border',
+});

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -73,9 +73,18 @@ export function ProblemSolveContainer({
         <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
         <HStack className={solutionStyle}>
           <Editor height="60%" code={problem.solutionCode} onChangeCode={handleChangeCode}></Editor>
-          <section className={css({ height: '40%', overflow: 'auto' })}>
-            <SimulationResultList resultList={simulation.results}></SimulationResultList>
-            <SubmissionResult></SubmissionResult>
+          <section className={resultContainerStyle}>
+            <div
+              className={css({
+                borderRadius: '0.5rem',
+                bg: 'surface',
+                maxHeight: '100%',
+                overflow: 'auto',
+              })}
+            >
+              <SimulationResultList resultList={simulation.results}></SimulationResultList>
+              <SubmissionResult></SubmissionResult>
+            </div>
           </section>
         </HStack>
       </VStack>
@@ -126,4 +135,10 @@ const footerStyle = css({
   borderTop: '1px solid',
   borderColor: 'border',
   placeItems: 'center',
+});
+
+const resultContainerStyle = css({
+  height: '40%',
+  overflow: 'auto',
+  padding: '1rem',
 });

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -72,7 +72,7 @@ export function ProblemSolveContainer({
       <VStack className={problemSolveContainerStyle}>
         <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
         <HStack className={solutionStyle}>
-          <Editor height="60%" code={problem.solutionCode} onChangeCode={handleChangeCode}></Editor>
+          <Editor height="50%" code={problem.solutionCode} onChangeCode={handleChangeCode}></Editor>
           <section className={resultContainerStyle}>
             <div
               className={css({
@@ -109,7 +109,9 @@ export function ProblemSolveContainer({
     </HStack>
   );
 }
-
+/**
+ * TODO: 탭스크린 만들기
+ */
 const problemSolveContainerStyle = css({
   height: 'calc(100% - 4rem)',
   width: 'full',
@@ -138,7 +140,7 @@ const footerStyle = css({
 });
 
 const resultContainerStyle = css({
-  height: '40%',
+  height: '50%',
   overflow: 'auto',
   padding: '1rem',
 });

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -129,4 +129,5 @@ const footerStyle = css({
   gap: '0.5rem',
   borderTop: '1px solid',
   borderColor: 'border',
+  placeItems: 'center',
 });

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -72,13 +72,8 @@ export function ProblemSolveContainer({
       <VStack className={problemSolveContainerStyle}>
         <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
         <HStack className={solutionStyle}>
-          <Editor
-            height="500px"
-            width="100%"
-            code={problem.solutionCode}
-            onChangeCode={handleChangeCode}
-          ></Editor>
-          <section>
+          <Editor height="60%" code={problem.solutionCode} onChangeCode={handleChangeCode}></Editor>
+          <section className={css({ height: '40%', overflow: 'auto' })}>
             <SimulationResultList resultList={simulation.results}></SimulationResultList>
             <SubmissionResult></SubmissionResult>
           </section>

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -63,16 +63,12 @@ export function ProblemSolveContainer({
     modal.open();
   }
 
-  useEffect(() => {
-    setCode(problem.solutionCode);
-  }, [problem.solutionCode, setCode]);
-
   return (
     <HStack className={css({ height: '100%' })} {...props}>
       <VStack className={problemSolveContainerStyle}>
         <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
         <HStack className={solutionStyle}>
-          <Editor height="50%" code={problem.solutionCode} onChangeCode={handleChangeCode}></Editor>
+          <Editor height="50%" code={code} onChangeCode={handleChangeCode}></Editor>
           <section className={resultContainerStyle}>
             <div
               className={css({

--- a/frontend/src/components/Simulation/SimulationResultList.tsx
+++ b/frontend/src/components/Simulation/SimulationResultList.tsx
@@ -25,7 +25,7 @@ function SimulationResult({ result }: { result: SimulationResult }) {
   return (
     <>
       <VStack className={resultContainerStyle}>
-        {result.isDone ? <Icon.CheckRound color="success" /> : <Icon.Spinner />}
+        {result.isDone ? <Icon.CheckRound color="success" /> : <Icon.Spinner spin />}
         <HStack className={resultDescriptionStyle}>
           <p>입력: {result.input}</p>
           <p>출력: {String(result.output)}</p>
@@ -44,6 +44,7 @@ const listStyle = css({
 });
 
 const resultContainerStyle = css({
+  alignItems: 'flex-start',
   padding: '1rem',
   gap: '0.625rem',
 });

--- a/frontend/src/components/Simulation/SimulationResultList.tsx
+++ b/frontend/src/components/Simulation/SimulationResultList.tsx
@@ -1,25 +1,53 @@
+import { css, cx } from '@style/css';
+
 import type { HTMLAttributes } from 'react';
 
+import { HStack, Icon, VStack } from '@/components/Common';
 import type { SimulationResult } from '@/hooks/simulation';
 
 interface Props extends HTMLAttributes<HTMLUListElement> {
   resultList: SimulationResult[];
 }
 
-export function SimulationResultList(props: Props) {
-  const { resultList = [] } = props;
-
+export function SimulationResultList({ resultList = [], className, ...props }: Props) {
   return (
-    <ul>
+    <ul className={cx(className)} {...props}>
       {resultList.map((result) => (
-        <li key={result.id}>
-          <div>
-            <p>입력: {result.input}</p>
-            <p>결과: {String(result.output)}</p>
-            <hr />
-          </div>
+        <li key={result.id} className={cx(listStyle)}>
+          <SimulationResult result={result}></SimulationResult>
         </li>
       ))}
     </ul>
   );
 }
+
+function SimulationResult({ result }: { result: SimulationResult }) {
+  return (
+    <>
+      <VStack className={resultContainerStyle}>
+        {result.isDone ? <Icon.CheckRound color="success" /> : <Icon.Spinner />}
+        <HStack className={resultDescriptionStyle}>
+          <p>입력: {result.input}</p>
+          <p>출력: {String(result.output)}</p>
+        </HStack>
+      </VStack>
+    </>
+  );
+}
+
+const listStyle = css({
+  borderBottom: '1px solid',
+  borderColor: 'border',
+  _last: {
+    borderBottom: 'none',
+  },
+});
+
+const resultContainerStyle = css({
+  padding: '1rem',
+  gap: '0.625rem',
+});
+
+const resultDescriptionStyle = css({
+  gap: '0.5rem',
+});

--- a/frontend/src/components/Submission/SubmissionButton.tsx
+++ b/frontend/src/components/Submission/SubmissionButton.tsx
@@ -1,4 +1,4 @@
-import { cx } from '@style/css';
+import { css, cx } from '@style/css';
 
 import { HTMLAttributes, useContext } from 'react';
 
@@ -40,8 +40,17 @@ export function SubmissionButton({ code, problemId, competitionId, className, ..
   }
 
   return (
-    <Button className={cx(className)} onClick={handleSubmitSolution} {...props}>
+    <Button
+      theme="brand"
+      className={cx(className, style)}
+      onClick={handleSubmitSolution}
+      {...props}
+    >
       제출하기
     </Button>
   );
 }
+
+const style = css({
+  paddingX: '2rem',
+});

--- a/frontend/src/hooks/editor/useUserCode.ts
+++ b/frontend/src/hooks/editor/useUserCode.ts
@@ -50,7 +50,6 @@ export function useUserCode({
 
   useEffect(() => {
     const userCode = getUserCode([localStorageKey, competitionKey, String(currentProblemIndex)]);
-
     if (typeof userCode === 'string') {
       setCode(userCode);
     } else {

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -116,6 +116,7 @@ export default function CompetitionPage() {
           <aside className={asideStyle}>
             <CompetitionProblemSelector
               problemIds={problemIds}
+              currentIndex={currentProblemIndex}
               onChangeProblemIndex={setCurrentProblemIndex}
             />
           </aside>
@@ -190,6 +191,7 @@ const asideStyle = css({
   borderRight: '1px solid',
   borderColor: 'border',
   padding: '0.5rem',
+  width: '5rem',
   height: '100%',
 });
 

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -121,7 +121,7 @@ export default function CompetitionPage() {
             />
           </aside>
           <HStack className={css({ height: '100%' })}>
-            <VStack className={hfullStyle}>
+            <VStack className={problemSolveContainerStyle}>
               <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
               <HStack className={solutionStyle}>
                 <Editor height="500px" code={code} onChangeCode={handleChangeCode}></Editor>
@@ -168,16 +168,18 @@ const competitionStyle = css({
   flexGrow: '1',
   overflow: 'hidden',
 });
-const hfullStyle = css({
+const problemSolveContainerStyle = css({
   height: 'calc(100% - 4rem)',
+  width: 'full',
 });
 const problemStyle = css({
-  width: '50%',
+  width: '1/2',
   height: '100%',
 });
 const solutionStyle = css({
-  width: '50%',
+  width: '1/2',
   height: '100%',
+  alignItems: 'stretch',
   overflow: 'auto',
 });
 

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -79,22 +79,13 @@ export default function CompetitionPage() {
             />
           </aside>
           <ProblemSolveContainer
-            competitionId={0}
-            problem={{
-              id: 0,
-              title: '',
-              timeLimit: 0,
-              memoryLimit: 0,
-              content: '',
-              solutionCode: '',
-              testcases: [],
-              createdAt: '',
-            }}
+            competitionId={competitionId}
+            problem={problem}
+            currentProblemIndex={currentProblemIndex}
           ></ProblemSolveContainer>
         </div>
         <DashboardModal isOpen={isDashboardModalOpen} onClose={closeDashboardModal} />
       </SocketProvider>
-      <DashboardModal isOpen={isDashboardModalOpen} onClose={closeDashboardModal} />
     </PageLayout>
   );
 }

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -3,9 +3,7 @@ import { css } from '@style/css';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { Button, Space } from '@/components/Common';
-import BreadCrumb from '@/components/Common/BreadCrumb';
-import Logo from '@/components/Common/Logo';
+import { BreadCrumb, Button, Logo, Space } from '@/components/Common';
 import { SocketProvider } from '@/components/Common/Socket/SocketProvider';
 import CompetitionHeader from '@/components/Competition/CompetitionHeader';
 import CompetitionProblemSelector from '@/components/Competition/CompetitionProblemSelector';

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button, HStack, Modal, Space, VStack } from '@/components/Common';
 import BreadCrumb from '@/components/Common/BreadCrumb';
+import Logo from '@/components/Common/Logo';
 import { SocketProvider } from '@/components/Common/Socket/SocketProvider';
 import CompetitionHeader from '@/components/Competition/CompetitionHeader';
 import CompetitionProblemSelector from '@/components/Competition/CompetitionProblemSelector';
@@ -104,6 +105,7 @@ export default function CompetitionPage() {
         namespace={'competitions'}
       >
         <CompetitionHeader className={padVerticalStyle}>
+          <Logo size={48}></Logo>
           <BreadCrumb crumbs={crumbs}></BreadCrumb>
           <Space></Space>
           <Button onClick={openDashboardModal}>대시보드 보기</Button>

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -169,7 +169,7 @@ const competitionStyle = css({
   overflow: 'hidden',
 });
 const hfullStyle = css({
-  height: 'calc(100% - 50px)',
+  height: 'calc(100% - 4rem)',
 });
 const problemStyle = css({
   width: '50%',
@@ -196,8 +196,10 @@ const asideStyle = css({
 });
 
 const footerStyle = css({
-  height: '50px',
+  height: '4rem',
   width: '100%',
-  paddingX: '0.5rem',
+  paddingX: '1rem',
   gap: '0.5rem',
+  borderTop: '1px solid',
+  border: 'border',
 });

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -176,6 +176,7 @@ const problemStyle = css({
 });
 const solutionStyle = css({
   width: '50%',
+  height: '100%',
   overflow: 'auto',
 });
 

--- a/frontend/src/utils/type/__tests__/isNumber.ts
+++ b/frontend/src/utils/type/__tests__/isNumber.ts
@@ -1,0 +1,21 @@
+import { isNumber } from '../index';
+import { describe, expect, it } from 'vitest';
+
+describe('isNumber', () => {
+  it('입력값이 숫자라면 true를 반환한다.', () => {
+    expect(isNumber(0)).toBe(true);
+    expect(isNumber(1)).toBe(true);
+    expect(isNumber(+1)).toBe(true);
+    expect(isNumber(-1)).toBe(true);
+    expect(isNumber(-0)).toBe(true);
+    expect(isNumber(+0)).toBe(true);
+    expect(isNumber(Number(0))).toBe(true);
+  });
+
+  it.each([[''], ['0'], [String('')], [true], [false], [{}], [() => {}]])(
+    'isNumber(%s) -> false',
+    (input) => {
+      expect(isNumber(input)).toBe(false);
+    },
+  );
+});

--- a/frontend/src/utils/type/index.ts
+++ b/frontend/src/utils/type/index.ts
@@ -24,3 +24,9 @@ export const isFunction = (type: unknown): type is Fn => {
 
   return false;
 };
+
+export const isNumber = (type: unknown): type is number => {
+  if (typeof type === 'number') return true;
+
+  return false;
+};


### PR DESCRIPTION
## 한 일

대회 화면 레이아웃 개선

테스트 케이스 추가 모달은 변경하지 않았습니다. 이 부분은 실제 테스트 케이스를 넣어 동작하게 되면 작업할 예정
테스트 결과 화면과 제출 결과 화면 분리도 구현하지 않았습니다. 이 PR이 너무 커져서 다음 테스크로 진행할 예정입니다.

## 스크린 샷

https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/44d7e1ef-15f4-4169-85e1-7d1fa42cf113

문제 이동, 코드 입력, 테스트 실행 등이 동작함을 확인할 수 있음