### PR TITLE
[#208] 로그인 url 하드코딩된 것 수정하기

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import Login from '@/components/Login';
 
-const GITHUB_AUTH_URL = 'http://101.101.208.240:3000/auths/github';
+const GITHUB_AUTH_URL = import.meta.env.VITE_GITHUB_AUTH_URL;
 
 export default function LoginPage() {
   // 넘겨주는 함수는 handle, 함수를 넘길 때의 프로펄티 네임은 on


### PR DESCRIPTION
## 한 일
GITHUB_AUTH_URL을 환경변수로 분리함

.env에 https://api.algo-with-me.site/auths/github 추가해주세요 

```
import Login from '@/components/Login';

const GITHUB_AUTH_URL = import.meta.env.VITE_GITHUB_AUTH_URL;

export default function LoginPage() {
  // 넘겨주는 함수는 handle, 함수를 넘길 때의 프로펄티 네임은 on
  const handleLogin = () => {
    try {
      window.location.href = GITHUB_AUTH_URL;
    } catch (e) {
      const error = e as Error;
      console.error(error.message);
    }
  };

  return <Login onClickLogin={handleLogin} />;
}
```