### PR TITLE
[#211] 대시보드 조회시 서버 죽는 문제 해결

### DIFF
--- a/be/algo-with-me-api/src/dashboard/dashboard.controller.ts
+++ b/be/algo-with-me-api/src/dashboard/dashboard.controller.ts
@@ -43,7 +43,7 @@ export class DashboardController {
 
   @ApiOperation({ summary: '[백엔드 테스트용] redis 대회 참가, 수정, 대시보드 조회 테스트' })
   @Get('all/:competitionId')
-  async getDashboardTest(@Param('competitionId') competitionId: number = 5) {
+  async dashboardTest(@Param('competitionId') competitionId: number = 5) {
     await this.dashboardService.registerUserAtCompetition(competitionId, 'dhdgn@naver.com');
     await this.dashboardService.registerUserAtCompetition(competitionId, 'qwer@naver.com');
     await this.dashboardService.updateUserSubmission(
@@ -53,7 +53,13 @@ export class DashboardController {
       RESULT.CORRECT,
       new Date(),
     );
-    await this.dashboardService.getTop100DashboardRedis(5, 'dhdgn@naver.com');
+    await this.dashboardService.getTop100DashboardRedis(competitionId, 'dhdgn@naver.com');
+  }
+
+  @ApiOperation({ summary: '[백엔드 테스트용] 대시보드 조회 테스트' })
+  @Get('test/:competitionId')
+  async getDashboardTest(@Param('competitionId') competitionId: number = 5) {
+    return await this.dashboardService.getTop100DashboardRedis(competitionId, 'dhdgn@naver.com');
   }
 
   @ApiOperation({ summary: '대회 종료 이후 대시보드 조회' })

--- a/be/algo-with-me-api/src/dashboard/dashboard.service.ts
+++ b/be/algo-with-me-api/src/dashboard/dashboard.service.ts
@@ -165,6 +165,9 @@ export class DashboardService {
       rankings.push({ email: scores[i], score: scores[i + 1] });
       emails.push(scoreKey + ':' + scores[i]);
     }
+
+    if (emails.length === 0) return { rankings, emails };
+
     const problems = await this.redis.mget(emails);
     this.logger.debug(problems);
     for (const [idx, ranking] of rankings.entries()) {


### PR DESCRIPTION
대시보드 조회할 때 mget으로 redis에서 유저들의 문제풀이 현황을 가져오는데, 매개변수로 들어가는 배열이 비어있을 경우 에러가 터져 서버가 멈춰버리는 문제가 있었습니다.
```javascript
const problems = await this.redis.mget(emails);
```
emails가 비어있을 경우 조기 리턴해주는 로직을 추가했습니다.

## 참고
https://www.notion.so/39f47ac3813f4bc79b825cb07d43d12d?pvs=4