### PR TITLE
[#211] 비동기라서 throw error 안되는 문제 해결

### DIFF
--- a/be/algo-with-me-api/src/dashboard/dashboard.gateway.ts
+++ b/be/algo-with-me-api/src/dashboard/dashboard.gateway.ts
@@ -28,11 +28,11 @@ export class DashboardGateway implements OnGatewayConnection {
     client.emit('dashboard', dashboard);
   }
 
-  public handleConnection(client: Socket, ...args: any[]) {
+  public async handleConnection(client: Socket, ...args: any[]) {
     try {
       const { competitionId } = client.handshake.query;
       client.data['competitionId'] = competitionId;
-      this.competitionService.isCompetitionFinished(Number(competitionId));
+      await this.competitionService.isCompetitionFinished(Number(competitionId));
       client.join(competitionId);
       this.logger.debug(
         `dashboard 웹소켓 연결 성공, competition id: ${competitionId}, client id: ${client.id}, args: ${args}`,


### PR DESCRIPTION
대시보드 조회시 종료된 대회면 에러를 터트리고 소켓 연결을 끊는 로직이 있는데, await을 걸어주지 않아 여기에서 에러가 터져도 잡지 못하는 문제가 발생했습니다. 이로인해 서버가 그냥 아무 응답없이 죽어버렸습니다. 문제 해결을 위해 await, async를 걸어줬더니 잘 동작함을 확인할 수 있었습니다.

## 참고
https://www.notion.so/39f47ac3813f4bc79b825cb07d43d12d?pvs=4