### PR TITLE
[#214] 대회 상세보기 페이지 상태 버그

### DIFF
--- a/frontend/src/components/CompetitionDetail/CompetitionDetailContent.tsx
+++ b/frontend/src/components/CompetitionDetail/CompetitionDetailContent.tsx
@@ -19,7 +19,7 @@ export function CompetitionDetailContent({
   competitionSchedule,
 }: Props) {
   const currentDate = new Date();
-  return <AfterCompetition {...{ competitionId, competition, competitionSchedule }} />;
+
   if (currentDate < startsAt) {
     return (
       <BeforeCompetition

--- a/frontend/src/pages/CompetitionDetailPage.tsx
+++ b/frontend/src/pages/CompetitionDetailPage.tsx
@@ -39,4 +39,5 @@ const pageStyle = css({
   flexDirection: 'column',
   alignItems: 'center',
   gap: '136px',
+  height: '100vh',
 });


### PR DESCRIPTION
### 한 일
대회 상세보기 페이지에 접속하면 무조건 종료된 대회로 나오던 버그를 수정했습니다.

### 스크린샷
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/0266ad88-2b9b-4750-9bcd-90f7ad9b5867)
