### PR TITLE
[#202] 도커 로깅 폴더 공유, 도커 시간 한국시간으로 변경

### DIFF
--- a/be/docker-compose.yaml
+++ b/be/docker-compose.yaml
@@ -7,9 +7,12 @@ services:
       - /home/be/algo-with-me/problems/:/algo-with-me/problems/
       - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/
       - /home/be/algo-with-me/testcases/:/algo-with-me/testcases/
+      - /home/be/web12-algo-with-me/be/algo-with-me-api/log/:/algo-with-me-api/log
     network_mode: host
     env_file:
-      ./algo-with-me-api/.env
+      - ./algo-with-me-api/.env
+    environment:
+      TZ: "Asia/Seoul"
     user: be:be
     restart: always
   algo-with-me-score:
@@ -20,11 +23,13 @@ services:
       - /home/be/algo-with-me/problems/:/algo-with-me/problems/
       - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/
       - /home/be/algo-with-me/testcases/:/algo-with-me/testcases/
+      - /home/be/web12-algo-with-me/be/algo-with-me-score/log/:/algo-with-me-score/log
     network_mode: host
     env_file:
       - ./algo-with-me-score/.env
     environment:
       DOCKER_CONTAINER_COUNT: ${DOCKER_CONTAINER_COUNT}
+      TZ: "Asia/Seoul"
     user: be:be
     restart: always
   algo-with-me-docker:
@@ -37,6 +42,8 @@ services:
       - /home/be/algo-with-me/testcases/:/algo-with-me/testcases/
     network_mode: bridge
     user: 1001:1001
+    environment:
+      TZ: "Asia/Seoul"
     restart: always
     deploy:
       mode: replicated


### PR DESCRIPTION
- 로깅 파일이 저장 안되는 문제가 있었습니다. 확인해보니 도커 내부에만 저장되고 있어 호스트와 공유하도록 하였습니다.
- 도커의 시간이 UTC 기준으로 되어있어 한국시간으로 수정했습니다.

## 참고
https://www.notion.so/f374f7b414c54c10a62314aa024002fa?pvs=4