### PR TITLE
[#222] 로고 클릭시 메인 페이지로 이동

### DIFF
--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,5 +1,7 @@
 import { css } from '@style/css';
 
+import { Link } from 'react-router-dom';
+
 import { Button, Space, Text, VStack } from '@/components/Common';
 import { Logo } from '@/components/Common';
 import useAuth from '@/hooks/login/useAuth';
@@ -18,10 +20,14 @@ export default function Header() {
   return (
     <header className={headerWrapperStyle}>
       <VStack className={headerStyle}>
-        <Logo size="48px" />
-        <Text.Title bold size="lg" className={textStyle}>
-          Algo With Me
-        </Text.Title>
+        <Link to="/">
+          <Logo size="48px" />
+        </Link>
+        <Link to="/">
+          <Text.Title bold size="lg" className={textStyle}>
+            Algo With Me
+          </Text.Title>
+        </Link>
         <Space />
         {isLoggedin ? (
           <Button className={buttonStyle} theme="brand" onClick={handleLogout}>

--- a/frontend/src/components/Main/CompetitionTable.tsx
+++ b/frontend/src/components/Main/CompetitionTable.tsx
@@ -29,7 +29,7 @@ function formatTimeRemaining(startsAt: string, endsAt: string): string {
 
     return `시작까지 ${days}일 ${hours}:${minutes}:${seconds}`;
   } else {
-    return '진행중';
+    return '진행 중';
   }
 }
 
@@ -101,8 +101,10 @@ export default function CompetitionTable() {
             <td className={stateTdStyle}>
               {formatTimeRemaining(competition.startsAt, competition.endsAt) === '종료' ? (
                 <Chip theme="danger">종료</Chip>
-              ) : (
+              ) : formatTimeRemaining(competition.startsAt, competition.endsAt) === '진행 중' ? (
                 <Chip theme="success">진행 중</Chip>
+              ) : (
+                <Chip theme="info">시작 전</Chip>
               )}
             </td>
 


### PR DESCRIPTION
### 한 일

- Header부분의 로고 혹은 텍스트를 클릭하면 메인 페이지로 이동합니다.
  - common의 Link를 사용하려고 했는데, 밑줄이 들어가있어서 react의 Link를 사용했습니다.
- MainPage의 테이블에서 대회가 시작 전일 경우 시작 전 상태를 표시합니다.


### 스크린샷

- Header부분의 로고 혹은 텍스트를 클릭하면 메인 페이지로 이동합니다.
![Animation](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/7296bcf5-0888-484f-b07e-b08aca2c1e9b)
- MainPage의 테이블에서 대회가 시작 전일 경우 시작 전 상태를 표시합니다.
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/9d9b076e-4651-49d3-b5a6-057d889c7feb)