### PR TITLE
[#183] 서버에서 받은 테스트 케이스 관련 작업

### DIFF
--- a/frontend/src/apis/problems/types.ts
+++ b/frontend/src/apis/problems/types.ts
@@ -6,6 +6,25 @@ export type ProblemInfo = {
   id: ProblemId;
   title: string;
 };
+interface TestcaseBaseDictionary {
+  name: string;
+  type: string;
+}
+
+type ValueType = 'string' | 'number' | 'boolean';
+
+type InputType = ValueType | ValueType[] | ValueType[][];
+
+interface TestcaseDataDictionary {
+  input: InputType[];
+  output: ValueType;
+}
+
+export interface Testcase {
+  data: TestcaseDataDictionary[];
+  input: TestcaseBaseDictionary[];
+  output: TestcaseBaseDictionary;
+}
 
 export type CompetitionProblem = {
   id: ProblemId;
@@ -14,7 +33,7 @@ export type CompetitionProblem = {
   memoryLimit: number;
   content: string;
   solutionCode: string;
-  testcases: SimulationInput[];
+  testcases: SimulationInput[] | Testcase;
   createdAt: string;
 };
 

--- a/frontend/src/apis/problems/types.ts
+++ b/frontend/src/apis/problems/types.ts
@@ -33,7 +33,7 @@ export type CompetitionProblem = {
   memoryLimit: number;
   content: string;
   solutionCode: string;
-  testcases: SimulationInput[] | Testcase;
+  testcases: SimulationInput[];
   createdAt: string;
 };
 

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -39,7 +39,7 @@ export function ProblemSolveContainer({
     save: customLocalStorage.save,
   });
 
-  const simulation = useSimulation(problem.testcases as SimulationInput[]);
+  const simulation = useSimulation(problem.testcases);
 
   const handleChangeCode = (newCode: string) => {
     setCode(newCode);

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -39,7 +39,7 @@ export function ProblemSolveContainer({
     save: customLocalStorage.save,
   });
 
-  const simulation = useSimulation(problem.testcases);
+  const simulation = useSimulation(problem.testcases as SimulationInput[]);
 
   const handleChangeCode = (newCode: string) => {
     setCode(newCode);

--- a/frontend/src/components/Simulation/SimulationResultList.tsx
+++ b/frontend/src/components/Simulation/SimulationResultList.tsx
@@ -28,6 +28,7 @@ function SimulationResult({ result }: { result: SimulationResult }) {
         {result.isDone ? <Icon.CheckRound color="success" /> : <Icon.Spinner spin />}
         <HStack className={resultDescriptionStyle}>
           <p>입력: {result.input}</p>
+          <p>기댓값: {result.expected}</p>
           <p>출력: {String(result.output)}</p>
         </HStack>
       </VStack>

--- a/frontend/src/components/SocketTimer/index.tsx
+++ b/frontend/src/components/SocketTimer/index.tsx
@@ -10,6 +10,7 @@ import { SocketContext } from '../Common/Socket/SocketContext';
 
 interface Props {
   onTimeout?: () => void;
+  endsAt: string;
 }
 
 const COMPEITION_PING_TIME = 5 * 1000;
@@ -17,10 +18,7 @@ const COMPEITION_SOCKET_EVENT = 'ping';
 
 export default function SocketTimer(props: Props) {
   const { socket, isConnected } = useContext(SocketContext);
-  const { onTimeout } = props;
-  // 대회 시간 검증이 안 되어 있어서, 끝나는 시간이 현재 시간보다 모두 전입니다. 그래서 지금 시간 기준으로 120분 더하고 마지막 시간이다라고 가정합니다.
-  const min = 120;
-  const endsAt = new Date(new Date().getTime() + min * 60 * 1000);
+  const { onTimeout, endsAt } = props;
 
   const { remainMiliSeconds, isTimeout } = useSocketTimer({
     socket,

--- a/frontend/src/hooks/problem/useCompetitionProblem.ts
+++ b/frontend/src/hooks/problem/useCompetitionProblem.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import type { CompetitionProblem, ProblemId } from '@/apis/problems';
+import type { CompetitionProblem, ProblemId, Testcase } from '@/apis/problems';
 import { fetchCompetitionProblem } from '@/apis/problems';
 import { isNil } from '@/utils/type';
 
@@ -28,12 +28,16 @@ export const useCompetitionProblem = (problemId: ProblemId) => {
       return;
     }
 
-    /**
-     * 서버에서 실제 테스트케이스를 받기 전 임시로 저장한 입력
-     */
+    const { data } = problem.testcases as Testcase;
+
     setProblem({
       ...problem,
-      testcases: [{ id: 1, input: '1,2', expected: '3', changable: false }],
+      testcases: data.map(({ input, output }, index) => ({
+        id: index + 1,
+        input: input.map((el) => JSON.stringify(el)).join(','),
+        expected: JSON.stringify(output),
+        changable: false,
+      })),
     });
   }
 

--- a/frontend/src/hooks/problem/useCompetitionProblem.ts
+++ b/frontend/src/hooks/problem/useCompetitionProblem.ts
@@ -28,7 +28,7 @@ export const useCompetitionProblem = (problemId: ProblemId) => {
       return;
     }
 
-    const { data } = problem.testcases as Testcase;
+    const { data } = problem.testcases as unknown as Testcase;
 
     setProblem({
       ...problem,

--- a/frontend/src/hooks/simulation/types.ts
+++ b/frontend/src/hooks/simulation/types.ts
@@ -1,8 +1,8 @@
 export type SimulationInput = {
   id: number;
   input: string;
-  expected?: string;
-  changable?: boolean;
+  expected: string;
+  changable: boolean;
 };
 
 export type SimulationResult = {
@@ -10,4 +10,5 @@ export type SimulationResult = {
   isDone: boolean;
   input: string;
   output: unknown;
+  expected: string;
 };

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -65,7 +65,7 @@ export default function CompetitionPage() {
           <BreadCrumb crumbs={crumbs}></BreadCrumb>
           <Space></Space>
           <Button onClick={openDashboardModal}>대시보드 보기</Button>
-          <SocketTimer onTimeout={handleTimeout} />
+          <SocketTimer onTimeout={handleTimeout} endsAt={competition.endsAt} />
         </CompetitionHeader>
         <ProblemHeader className={padVerticalStyle} problem={problem}></ProblemHeader>
         <div className={competitionStyle}>


### PR DESCRIPTION
### 한 일

- 서버에서 받은 테스트 케이스 타입 지정
- 서버에서 받은 테스트 케이스를  시뮬레이션 input 타입으로 변경
- 테스트 결과창에 예상 값 추가


https://github.com/boostcampwm2023/web12-algo-with-me/assets/78193416/0499ef7e-26d3-42c0-a18f-5bf86a6cad71

### 테스트 케이스 타입에 대한 설명
- https://www.notion.so/434b7c29f1f94f30b342f075843aa7e9?pvs=4

### ps
웹 소켓 연결도 해버렸습니다. pr 나누고 싶지만, 내일 데모해야하니..

https://github.com/boostcampwm2023/web12-algo-with-me/assets/78193416/14c01e0b-1809-41bf-a481-257f4baec502

