### PR TITLE
[#226] 대회 참여 신청 후 페이지 에러

### DIFF
--- a/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
+++ b/frontend/src/components/CompetitionDetail/BeforeCompetition.tsx
@@ -3,7 +3,7 @@ import { css } from '@style/css';
 import { CompetitionInfo } from '@/apis/competitions';
 
 import { Button, Chip, Text, VStack } from '../Common';
-import JoinCompetitionButton from '../Main/Buttons/JoinCompetitionButton';
+import JoinCompetitionButton from './Buttons/JoinCompetitionButton';
 import CompetitionDetailInfo from './CompetitionDetailInfo';
 import CompetitionMembersInfo from './CompetitionMembersInfo';
 import { buttonContainerStyle } from './styles/styles';

--- a/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
+++ b/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
@@ -23,7 +23,6 @@ export default function JoinCompetitionButton(props: { id: number }) {
 
     const result = await joinCompetition(competitionData);
     alert(result);
-    navigate(`/contest/detail/${props.id}`);
   };
   const competitionData: CompetitionApiData = {
     id: props.id,

--- a/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
+++ b/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
@@ -23,6 +23,7 @@ export default function JoinCompetitionButton(props: { id: number }) {
 
     const result = await joinCompetition(competitionData);
     alert(result);
+    navigate(`/contest/detail/${props.id}`);
   };
   const competitionData: CompetitionApiData = {
     id: props.id,

--- a/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
+++ b/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
@@ -23,7 +23,7 @@ export default function JoinCompetitionButton(props: { id: number }) {
 
     const result = await joinCompetition(competitionData);
     alert(result);
-    navigate(`/contest/detail/${props.id}`);
+    navigate(0);
   };
   const competitionData: CompetitionApiData = {
     id: props.id,

--- a/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
+++ b/frontend/src/components/CompetitionDetail/Buttons/JoinCompetitionButton.tsx
@@ -23,7 +23,7 @@ export default function JoinCompetitionButton(props: { id: number }) {
 
     const result = await joinCompetition(competitionData);
     alert(result);
-    navigate(0);
+    navigate(`/contest/detail/${props.id}`);
   };
   const competitionData: CompetitionApiData = {
     id: props.id,

--- a/frontend/src/components/Main/Buttons/JoinCompetitionButton.tsx
+++ b/frontend/src/components/Main/Buttons/JoinCompetitionButton.tsx
@@ -23,7 +23,6 @@ export default function JoinCompetitionButton(props: { id: number }) {
 
     const result = await joinCompetition(competitionData);
     alert(result);
-    window.location.reload();
   };
   const competitionData: CompetitionApiData = {
     id: props.id,


### PR DESCRIPTION
### 한 일
- 기존에 window.location.reload()코드를 navigate()로 바꿨습니다.
- 대회 참여는 대회 상세 정보 보기 페이지에서만 해서 버튼 컴포넌트의 위치를 바꿨고, navigate의 경로는 대회 상세 정보 보기 페이지로 작성했습니다.

### 스크린샷
netlyfi 임시 배포 페이지에서 실행했습니다.
![Animation](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/c95f8e34-1c7f-43e5-8b93-cbce923788ba)
