### PR TITLE
[#227] 테스트케이스가 다른 탭을 갔다 오면 사라지는 버그

### DIFF
--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -28,6 +28,8 @@ interface Props extends HStackProps {
   problem: CompetitionProblem;
 }
 
+const simulationInputCache: Record<`${CompetitionId}|${number}`, SimulationInput[]> = {};
+
 export function ProblemSolveContainer({
   currentProblemIndex,
   competitionId,
@@ -45,7 +47,13 @@ export function ProblemSolveContainer({
     save: customLocalStorage.save,
   });
 
-  const simulation = useSimulation(problem.testcases);
+  let testcases: SimulationInput[] = [];
+  if (isNil(simulationInputCache[`${competitionId}|${currentProblemIndex}`])) {
+    testcases = problem.testcases;
+  } else {
+    testcases = simulationInputCache[`${competitionId}|${currentProblemIndex}`];
+  }
+  const simulation = useSimulation(testcases);
 
   const handleChangeCode = (newCode: string) => {
     setCode(newCode);
@@ -61,6 +69,7 @@ export function ProblemSolveContainer({
   };
 
   const handleSaveSimulationInputs = (simulationInputs: SimulationInput[]) => {
+    simulationInputCache[`${competitionId}|${currentProblemIndex}`] = simulationInputs;
     simulation.changeInputs(simulationInputs);
   };
 

--- a/frontend/src/hooks/simulation/useSimulation.ts
+++ b/frontend/src/hooks/simulation/useSimulation.ts
@@ -12,9 +12,13 @@ export const useSimulation = (testcases: SimulationInput[]) => {
     return results.some((result) => !result.isDone);
   }, [results]);
 
-  useEffect(() => {
+  function setupTestcase(testcases: SimulationInput[]) {
     setInputs(testcases);
     setResults(testcases.map(createResult));
+  }
+
+  useEffect(() => {
+    setupTestcase(testcases);
   }, [testcases]);
 
   useEffect(() => {
@@ -62,8 +66,7 @@ export const useSimulation = (testcases: SimulationInput[]) => {
   }
 
   function changeInputs(inputs: SimulationInput[]) {
-    setInputs(inputs);
-    setResults(inputs.map(createResult));
+    setupTestcase(inputs);
   }
 
   function cancel() {


### PR DESCRIPTION
## 한 일

테스트케이스가 다른 탭을 갔다 오면 사라지는 버그 수정

*이 방식은 임시적인 방법입니다. 메모리에 테스트케이스가 그대로 남아있어 한 페이지를 계속 켜놓고 다른 여러 대회를 하면 할 수록 메모리를 먹게 됩니다. 시간상의 문제로 임시 해결 했음을 알립니다.

## 스크린 샷
![results](https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/eee66c7e-4f9b-41dd-ac48-7ed4174789cf)

추가 후 다른 탭을 이동했다 와도 테스트케이스가 남아 있음