### PR TITLE
[#228] 대회 페이지 내에서 검증 실패가 되면 메인 페이지로 이동

### DIFF
--- a/frontend/src/components/UserValidator/index.tsx
+++ b/frontend/src/components/UserValidator/index.tsx
@@ -9,6 +9,7 @@ export function UserValidator() {
   const navigate = useNavigate();
 
   const handleMessage = useCallback(() => {
+    alert('유효하지 않은 접근입니다.');
     navigate('/');
   }, []);
 

--- a/frontend/src/components/UserValidator/index.tsx
+++ b/frontend/src/components/UserValidator/index.tsx
@@ -1,0 +1,23 @@
+import { useCallback, useContext, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { SocketContext } from '../Common/Socket/SocketContext';
+
+export function UserValidator() {
+  const { socket, isConnected } = useContext(SocketContext);
+
+  const navigate = useNavigate();
+
+  const handleMessage = useCallback(() => {
+    navigate('/');
+  }, []);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    if (!socket?.hasListeners('message')) {
+      socket.on('message', handleMessage);
+    }
+  }, [socket, isConnected]);
+  return <></>;
+}

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -46,7 +46,7 @@ export default function CompetitionPage() {
   const problemIds = problemList.map((problem) => problem.id);
 
   function handleTimeout() {
-    navigate(`${ROUTE.DASHBOARD}/${competitionId}`);
+    navigate('/');
   }
 
   const { competition } = useCompetition(competitionId);

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -12,6 +12,7 @@ import { PageLayout } from '@/components/Layout/PageLayout';
 import { ProblemHeader } from '@/components/Problem/ProblemHeader';
 import { ProblemSolveContainer } from '@/components/Problem/ProblemSolveContainer';
 import SocketTimer from '@/components/SocketTimer';
+import { UserValidator } from '@/components/UserValidator';
 import { ROUTE, SITE } from '@/constants';
 import { useCompetition } from '@/hooks/competition';
 import { useCompetitionProblem } from '@/hooks/problem';
@@ -90,6 +91,7 @@ export default function CompetitionPage() {
           competitionName={competition.name}
           competitionId={competitionId}
         />
+        <UserValidator />
       </SocketProvider>
     </PageLayout>
   );

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -13,7 +13,7 @@ import { ProblemHeader } from '@/components/Problem/ProblemHeader';
 import { ProblemSolveContainer } from '@/components/Problem/ProblemSolveContainer';
 import SocketTimer from '@/components/SocketTimer';
 import { UserValidator } from '@/components/UserValidator';
-import { ROUTE, SITE } from '@/constants';
+import { SITE } from '@/constants';
 import { useCompetition } from '@/hooks/competition';
 import { useCompetitionProblem } from '@/hooks/problem';
 import { useCompetitionProblemList } from '@/hooks/problem/useCompetitionProblemList';


### PR DESCRIPTION
### 한 일

- websocket 관련 모든 error는 message event로 전달됨.
- 대회 페이지에서 message event가 오면 문제가 발생한 경우라 main 페이지로 이동해서 다시 검증하도록함.
- 한 사용자가 하나의 대회에 여러 탭에서 참여했을 때도 마찬가지로 message로 event가 오기 때문에 똑같이 메인 페이지로 이동하게 함.

### ps

- 소켓을 프로파이버로 사용하고 있어서 어느 컴포넌트에서 이러한 작업을 할까 고민하다 적절한 도메인이 없어서
- <></>를 반환하는 컴포넌트안에 해당 로직을 넣었는데 어떻게 생각하시나요?

- 시간 끝나면 대시보드 페이지로 네비게이션 하던 것도 main 페이지로 일단 바꿨습니다. 집계 후에 나오니까.

### 화면

https://github.com/boostcampwm2023/web12-algo-with-me/assets/78193416/1e171850-1045-4e30-8da6-e2683bfacf7a

