### PR TITLE
[#236] 1차 데모 이후 발생한 문제 수정

### DIFF
--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -21,6 +21,7 @@ import { CompetitionDto } from '../dto/competition.dto';
 import { IsJoinableDto } from '../dto/competition.is.joinable.dto';
 import { CompetitionProblemResponseDto } from '../dto/competition.problem.response.dto';
 import { CompetitionResponseDto } from '../dto/competition.response.dto';
+import { CompetitionSimpleResponseDto } from '../dto/competition.simple-response.dto';
 import { ProblemSimpleResponseDto } from '../dto/problem.simple.response.dto';
 import { ScoreResultDto } from '../dto/score-result.dto';
 import { CompetitionService } from '../services/competition.service';
@@ -38,7 +39,7 @@ export class CompetitionController {
     summary: '대회 정보 전체 조회',
     description: '모든 대회 정보를 조회한다.',
   })
-  @ApiResponse({ type: CompetitionResponseDto })
+  @ApiResponse({ type: CompetitionSimpleResponseDto })
   findAll() {
     return this.competitionService.findAll();
   }

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -105,7 +105,6 @@ export class CompetitionController {
   })
   @UsePipes(new ValidationPipe({ transform: true }))
   async saveScoreResult(@Body() scoreResultDto: ScoreResultDto) {
-    this.logger.debug('채점완료 api', scoreResultDto);
     await this.competitionService.saveScoreResult(scoreResultDto);
   }
 

--- a/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
+++ b/be/algo-with-me-api/src/competition/controllers/competition.controller.ts
@@ -7,7 +7,6 @@ import {
   Param,
   Post,
   Put,
-  Req,
   UseGuards,
   UsePipes,
   ValidationPipe,
@@ -116,8 +115,8 @@ export class CompetitionController {
   })
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  async joinCompetition(@Req() req, @Param('competitionId') competitionId: number) {
-    await this.competitionService.joinCompetition(competitionId, req.user.email);
+  async joinCompetition(@AuthUser() user: User, @Param('competitionId') competitionId: number) {
+    await this.competitionService.joinCompetition(competitionId, user);
   }
 
   @Get('validation/:competitionId')

--- a/be/algo-with-me-api/src/competition/dto/competition.simple-response.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/competition.simple-response.dto.ts
@@ -9,6 +9,7 @@ export class CompetitionSimpleResponseDto {
     name: string,
     detail: string,
     maxParticipants: number,
+    participants: number,
     startsAt: string,
     endsAt: string,
     createdAt: string,
@@ -18,6 +19,7 @@ export class CompetitionSimpleResponseDto {
     this.name = name;
     this.detail = detail;
     this.maxParticipants = maxParticipants;
+    this.participants = participants;
     this.startsAt = startsAt;
     this.endsAt = endsAt;
     this.createdAt = createdAt;
@@ -40,6 +42,9 @@ export class CompetitionSimpleResponseDto {
   @IsNotEmpty()
   maxParticipants: number;
 
+  @ApiProperty({ description: '대회 참여중인 인원' })
+  participants: number;
+
   @ApiProperty({ description: '대회 시작 일시 (ISO string)' })
   @IsNotEmpty()
   startsAt: string;
@@ -56,12 +61,13 @@ export class CompetitionSimpleResponseDto {
   @IsNotEmpty()
   updatedAt: string;
 
-  static from(competition: Competition) {
+  static from(competition: Competition, participants: number) {
     return new CompetitionSimpleResponseDto(
       competition.id,
       competition.name,
       competition.detail,
       competition.maxParticipants,
+      participants,
       competition.startsAt.toISOString(),
       competition.endsAt.toISOString(),
       competition.createdAt.toISOString(),

--- a/be/algo-with-me-api/src/competition/dto/score-result.dto.ts
+++ b/be/algo-with-me-api/src/competition/dto/score-result.dto.ts
@@ -22,4 +22,13 @@ export class ScoreResultDto {
 
   @ApiProperty()
   stdout: string;
+
+  @ApiProperty()
+  stderr: string;
+
+  @ApiProperty({ description: 'ms' })
+  timeUsage: number;
+
+  @ApiProperty({ description: 'KB' })
+  memoryUsage: number;
 }

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -129,6 +129,7 @@ export class CompetitionService {
       queryRunner.manager.save(competitionProblems);
       await queryRunner.commitTransaction();
       await queryRunner.release();
+      return CompetitionResponseDto.from(savedCompetition, user.email, []);
     } catch (error) {
       await queryRunner.rollbackTransaction();
       await queryRunner.release();

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -62,9 +62,20 @@ export class CompetitionService {
 
   async findAll() {
     const competitionList = await this.competitionRepository.find();
-    return competitionList.map((competition) => {
-      return CompetitionSimpleResponseDto.from(competition);
-    });
+    const competitionSimpleResponseDtos: CompetitionSimpleResponseDto[] = [];
+    for (const competition of competitionList) {
+      // 대회별 참가자 rows를 조회해야 함. 응답 속도가 늦어진다면 참가자 수를 저장하는 column 추가 필요
+      const joinedUsers: CompetitionParticipant[] =
+        await this.competitionParticipantRepository.find({
+          where: {
+            competitionId: competition.id,
+          },
+        });
+      competitionSimpleResponseDtos.push(
+        CompetitionSimpleResponseDto.from(competition, joinedUsers.length),
+      );
+    }
+    return competitionSimpleResponseDtos;
   }
 
   async findOne(competitionId: number) {

--- a/be/algo-with-me-api/src/competition/services/competition.service.ts
+++ b/be/algo-with-me-api/src/competition/services/competition.service.ts
@@ -290,6 +290,8 @@ export class CompetitionService {
     const result = {
       testcaseId: scoreResultDto.testcaseId,
       result: scoreResultDto.result,
+      timeUsage: scoreResultDto.timeUsage,
+      memoryUsage: scoreResultDto.memoryUsage,
     };
 
     submission.detail.push(result);
@@ -323,6 +325,7 @@ export class CompetitionService {
     }
     result['problemId'] = submission.problemId;
     result['stdout'] = scoreResultDto.stdout;
+    result['stderr'] = scoreResultDto.stderr;
     this.server.to(scoreResultDto.socketId).emit('scoreResult', result);
   }
 


### PR DESCRIPTION
- 참여 가능 인원보다 많은 인원이 참여 되는 문제 수정
- 대회 생성 후 생성된 대회 정보 반환하도록 수정
- 클라이언트에게 보내주는 제출 결과에 stderr, memoryUsage, timeUsage 추가
    - stderr, stdout 은 출력이 매우 길어질 수 있기 때문에 db에 저장하지 않습니다.
- 대회 메인 페이지에서 진행중, 그렇지 않은 대회 정렬
    - 진행중인 대회는 상위 노출, 그렇지 않은 대회는 진행중인 대회 아래에 나오게 수정했습니다.
    - 기본 정렬 기준은 "대회 시작일" 입니다.
- 대회 목록, 대회 상세 api 응답에 참여중인 인원, 최대 참여 가능 인원 추가
    - 대회 상세엔 참가자 정보가 배열로 전달 되기 때문에 참여중인 인원을 따로 추가하지 않았습니다.
    - 대회 목록에는 참여중인 인원을 추가하였습니다.

## 참고
https://www.notion.so/1-b16be0fbc3584d76a48081a92204ca20?pvs=4