### PR TITLE
[#235] 채점서버 개수 늘리기

### DIFF
--- a/be/algo-with-me-score/Dockerfile
+++ b/be/algo-with-me-score/Dockerfile
@@ -11,6 +11,6 @@ COPY --chown=be:be ./ ./
 
 RUN pnpm install
 
-EXPOSE 4000
+EXPOSE 4000-4999
 
 CMD ["pnpm", "run", "start:dev"]

--- a/be/algo-with-me-score/src/main.ts
+++ b/be/algo-with-me-score/src/main.ts
@@ -6,6 +6,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
-  await app.listen(process.env.SELF_PORT);
+  await app.listen(4000 + parseInt(process.env.SCORE_SERVER_ID));
 }
 bootstrap();

--- a/be/algo-with-me-score/src/main.ts
+++ b/be/algo-with-me-score/src/main.ts
@@ -6,6 +6,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
-  await app.listen(4000);
+  await app.listen(process.env.SELF_PORT);
 }
 bootstrap();

--- a/be/algo-with-me-score/src/score/services/fetch.service.ts
+++ b/be/algo-with-me-score/src/score/services/fetch.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 
 import { ScoreResultDto } from '../dtos/score-result.dto';
@@ -38,11 +38,17 @@ export class FetchService {
     testcaseId: number,
     containerId: number,
   ): Promise<ICoderunResponse> {
-    const [dockerServerHost, dockerServerBasePort] = [
+    const [dockerServerHost, dockerServerBasePort, scoreServerId, dockerContainerCount] = [
       process.env.DOCKER_SERVER_HOST,
       process.env.DOCKER_SERVER_PORT,
+      process.env.SCORE_SERVER_ID,
+      process.env.DOCKER_CONTAINER_COUNT,
     ];
-    const dockerServerPort = (parseInt(dockerServerBasePort) + containerId).toString();
+    const dockerServerPort = (
+      parseInt(dockerServerBasePort) +
+      parseInt(scoreServerId) * parseInt(dockerContainerCount) +
+      containerId
+    ).toString();
     const url = `http://${dockerServerHost}:${dockerServerPort}/${competitionId}/${userId}/${problemId}/${testcaseId}`;
     try {
       const response = await fetch(url, { method: 'POST' });

--- a/be/docker-compose.yaml
+++ b/be/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       DOCKER_CONTAINER_COUNT: ${DOCKER_CONTAINER_COUNT}
       TZ: "Asia/Seoul"
-      SELF_PORT: 4000
+      SCORE_SERVER_ID: 0
     user: be:be
     restart: always
 
@@ -50,7 +50,7 @@ services:
     environment:
       DOCKER_CONTAINER_COUNT: ${DOCKER_CONTAINER_COUNT}
       TZ: "Asia/Seoul"
-      SELF_PORT: 4001
+      SCORE_SERVER_ID: 1
     user: be:be
     restart: always
 

--- a/be/docker-compose.yaml
+++ b/be/docker-compose.yaml
@@ -15,10 +15,11 @@ services:
       TZ: "Asia/Seoul"
     user: be:be
     restart: always
-  algo-with-me-score:
+
+  algo-with-me-score-0:
     image: algo-with-me-score
     ports:
-      - 4000:4000
+      - 4000
     volumes:
       - /home/be/algo-with-me/problems/:/algo-with-me/problems/
       - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/
@@ -30,12 +31,33 @@ services:
     environment:
       DOCKER_CONTAINER_COUNT: ${DOCKER_CONTAINER_COUNT}
       TZ: "Asia/Seoul"
+      SELF_PORT: 4000
     user: be:be
     restart: always
+
+  algo-with-me-score-1:
+    image: algo-with-me-score
+    ports:
+      - 4001
+    volumes:
+      - /home/be/algo-with-me/problems/:/algo-with-me/problems/
+      - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/
+      - /home/be/algo-with-me/testcases/:/algo-with-me/testcases/
+      - /home/be/web12-algo-with-me/be/algo-with-me-score/log/:/algo-with-me-score/log
+    network_mode: host
+    env_file:
+      - ./algo-with-me-score/.env
+    environment:
+      DOCKER_CONTAINER_COUNT: ${DOCKER_CONTAINER_COUNT}
+      TZ: "Asia/Seoul"
+      SELF_PORT: 4001
+    user: be:be
+    restart: always
+
   algo-with-me-docker:
     image: algo-with-me-docker
     ports:
-      - 5000-${DOCKER_PORT_RANGE_END}:5000
+      - ${DOCKER_PORT_RANGE_START}-${DOCKER_PORT_RANGE_END}:5000
     volumes:
       - /home/be/algo-with-me/problems/:/algo-with-me/problems/
       - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/
@@ -47,4 +69,4 @@ services:
     restart: always
     deploy:
       mode: replicated
-      replicas: ${DOCKER_CONTAINER_COUNT}
+      replicas: ${DOCKER_CONTAINER_COUNT_ALL}

--- a/be/docker-compose.yaml
+++ b/be/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
   algo-with-me-score-0:
     image: algo-with-me-score
     ports:
-      - 4000
+      - 4000:4000
     volumes:
       - /home/be/algo-with-me/problems/:/algo-with-me/problems/
       - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/
@@ -38,7 +38,7 @@ services:
   algo-with-me-score-1:
     image: algo-with-me-score
     ports:
-      - 4001
+      - 4001:4001
     volumes:
       - /home/be/algo-with-me/problems/:/algo-with-me/problems/
       - /home/be/algo-with-me/submissions/:/algo-with-me/submissions/


### PR DESCRIPTION
채점서버 개수 2개로 늘린 뒤 테스트했고 잘 동작하는 것 확인했습니다.

채점서버는 각각이 PromisePool을 가지고 있어, 도커서버에 일을 준 채점서버에서만 그 도커의 일이 끝났는지 확인할 수 있습니다.
그러므로 채점서버와 별도로 동작하며 도커서버 풀을 관리할 개체가 없다면, 도커서버들이 각 채점서버에 귀속되도록 해야 합니다.
간단히 나타내면 다음과 같은데, (괄호 안은 포트번호)

채점1 (4000) . . . . . . . . . . . . . . . . . . . . . . . . | 채점2 (4001) . . . . . . . . . . . . . . . . . . . . . . . . . 
도커1 도커2 도커3 도커4 도커5 (5000-5004) | 도커6 도커7 도커8 도커9 도커10 (5005-5009)

문제는 채점서버가 본인이 사용할 수 있는 도커가 무엇인지 알 수 없다는 것입니다. 즉 본인이 5000-5004 포트의 도커를 사용할 수 있을지, 5005-5009번 포트의 도커를 사용할 수 있을지 모릅니다.
포트번호 4000, 4001을 통해 알 수 있지 않느냐고 한다면 가능하지만(5000 + <자신의 포트> - 4000 * 5 ~), 안쪽의 채점서버는 자신이 바깥에 몇 번 포트로 드러나있는지 스스로 알 수 있는 방법이 없습니다.

https://stackoverflow.com/questions/39770712/how-can-a-container-identify-which-container-it-is-in-a-set-of-a-scaled-docker-c
https://devops.stackexchange.com/questions/5691/how-to-get-exposed-ports-from-inside-of-container

위와 같이 docker api를 사용하는 방법들이 존재한다고 하지만, 구조를 너무 복잡하게 만드는 것 같아서 일단 보류했습니다.
우선은 채점서버 2개를 만드는 것이 목적이니, 채점서버 2개롤(score-0, score-1) 만들고 환경변수로 자신의 포트를 알려줬습니다.

물론 이렇게 하면 scaling을 하기가 불편한데, 채점서버 개수를 늘릴 때마다 docker-compose.yaml에 늘릴 채점서버 개수만큼 service를 늘려줘야 하고, 포트번호도 하나씩 바꿔줘야 하기 때문입니다. 불편한 중복은 덤입니다.
도커서버에서 했던 것처럼 docker-compose.yaml에서 network 모드를 bridge로 한 뒤 `port: 5000-5009:5000`과 같이 설정해줄 수도 있지만 이렇게 하면 각 서버에게 자신의 외부 포트 번호를 하나씩 알려줄 수 없다는 문제가 있습니다.

즉 정리하자면 일단 scaling의 이점을 일부 포기하고 채점서버 개수를 늘렸습니다

가장 최상위의 .env에 `DOCKER_PORT_RANGE_START`와 `DOCKER_CONTAINER_COUNT_ALL`을 추가했으니 참고해주세요.
`DOCKER_PORT_RANGE_START`는 도커 컨테이너의 시작 포트를 (위 예시에서 5000),
`DOCKER_CONTAINER_COUNT_ALL`은 도커 컨테이너의 총 개수를 의미합니다 (위 예시에서 10)
배포서버에 미리 환경변수 넣어놓도록 하겠습니다
