### PR TITLE
[#249] 대회 페이지 아래에 빈 공간 생기는 버그 수정

### DIFF
--- a/frontend/src/components/Layout/CompetitionPageLayout.tsx
+++ b/frontend/src/components/Layout/CompetitionPageLayout.tsx
@@ -1,0 +1,19 @@
+import { css, cx } from '@style/css';
+
+import { HTMLAttributes } from 'react';
+
+interface Props extends HTMLAttributes<HTMLElement> {}
+
+export function CompetitionPageLayout({ children, className, ...props }: Props) {
+  return (
+    <main {...props} className={cx(style, className)}>
+      {children}
+    </main>
+  );
+}
+
+const style = css({
+  width: '100%',
+  color: 'text',
+  background: 'background',
+});

--- a/frontend/src/components/Layout/index.ts
+++ b/frontend/src/components/Layout/index.ts
@@ -1,0 +1,2 @@
+export { CompetitionPageLayout } from './CompetitionPageLayout';
+export { PageLayout } from './PageLayout';

--- a/frontend/src/pages/CompetitionPage.tsx
+++ b/frontend/src/pages/CompetitionPage.tsx
@@ -8,7 +8,7 @@ import { SocketProvider } from '@/components/Common/Socket/SocketProvider';
 import CompetitionHeader from '@/components/Competition/CompetitionHeader';
 import CompetitionProblemSelector from '@/components/Competition/CompetitionProblemSelector';
 import DashboardModal from '@/components/Dashboard/DashboardModal';
-import { PageLayout } from '@/components/Layout/PageLayout';
+import { CompetitionPageLayout } from '@/components/Layout';
 import { ProblemHeader } from '@/components/Problem/ProblemHeader';
 import { ProblemSolveContainer } from '@/components/Problem/ProblemSolveContainer';
 import SocketTimer from '@/components/SocketTimer';
@@ -54,7 +54,7 @@ export default function CompetitionPage() {
   const crumbs = [SITE.NAME, competition.name ?? ''];
 
   return (
-    <PageLayout className={style}>
+    <CompetitionPageLayout className={style}>
       <SocketProvider
         transports={['websocket']}
         query={{ competitionId: String(competitionId) }}
@@ -93,7 +93,7 @@ export default function CompetitionPage() {
         />
         <UserValidator />
       </SocketProvider>
-    </PageLayout>
+    </CompetitionPageLayout>
   );
 }
 

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -2,6 +2,7 @@ import { css } from '@style/css';
 
 import { HStack, Logo, Text, VStack } from '@/components/Common';
 import Header from '@/components/Header';
+import { PageLayout } from '@/components/Layout';
 import GoToCreateCompetitionLink from '@/components/Main/Buttons/GoToCreateCompetitionLink';
 import CompetitionTable from '@/components/Main/CompetitionTable';
 import { SITE } from '@/constants';
@@ -10,7 +11,7 @@ function MainPage() {
   return (
     <>
       <Header />
-      <main className={style}>
+      <PageLayout>
         <HStack className={logoAndTitleContainerStyle}>
           <Logo size="220px" />
           <Text type="display" size="lg" className={displayTextStyle}>
@@ -26,7 +27,7 @@ function MainPage() {
         <section className={competitionTableWrapperStyle}>
           <CompetitionTable />
         </section>
-      </main>
+      </PageLayout>
     </>
   );
 }
@@ -46,10 +47,6 @@ const displayTextStyle = css({
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
-});
-
-const style = css({
-  background: 'background',
 });
 
 const linkWrapperStyle = css({


### PR DESCRIPTION
## 한 일

- 메인 페이지 아래에 빈 공간 삽입
- 대회 페이지 아래의 빈 공간 제거


## 스크린 샷
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/d3cb5c4f-6c35-4559-adc4-574d7c108c33)
메인 페이지 아래의 빈 공간

![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/a49a4435-7126-4ab8-8988-d07dd2c107f5)
대회 페이지 아래는 빈 공간을 제거함