### PR TITLE
[#272] 제출 결과 시간 및 메모리 사용량 출력

### DIFF
--- a/frontend/src/components/Competition/CompetitionHeader.tsx
+++ b/frontend/src/components/Competition/CompetitionHeader.tsx
@@ -6,7 +6,7 @@ interface Props extends VStackProps {}
 
 export default function CompetitionHeader({ className, children, ...props }: Props) {
   return (
-    <VStack className={cx(className, headerStyle)} as="header" {...props}>
+    <VStack alignItems="center" className={cx(className, headerStyle)} as="header" {...props}>
       {children}
     </VStack>
   );

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -110,14 +110,14 @@ export function ProblemSolveContainer({
       testcaseId: number;
     },
   ) => {
-    const { problemId, result, stdOut, testcaseId } = data;
+    const { problemId, result, stdout, testcaseId } = data;
     const newResult = {
       testcaseId,
       submitState: SUBMIT_STATE.submitted,
       score: {
         problemId,
         result,
-        stdOut,
+        stdout,
       } satisfies ScoreResult,
     };
     submission.changeDoneScoreResult(newResult);

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -160,7 +160,7 @@ export function ProblemSolveContainer({
 
   return (
     <HStack className={css({ height: '100%' })} {...props}>
-      <VStack className={problemSolveContainerStyle}>
+      <VStack className={problemSolveContainerStyle} alignItems="stretch">
         <ProblemViewer className={problemStyle} content={problem.content}></ProblemViewer>
         <HStack className={solutionStyle}>
           <Editor height="50%" code={code} onChangeCode={handleChangeCode}></Editor>
@@ -185,7 +185,7 @@ export function ProblemSolveContainer({
           </section>
         </HStack>
       </VStack>
-      <VStack as="footer" className={footerStyle}>
+      <VStack as="footer" alignItems="center" className={footerStyle}>
         <Button onClick={handleOpenModal}>테스트 케이스 추가하기</Button>
         <Space></Space>
         <Button onClick={handleInitCode}>코드 초기화하기</Button>

--- a/frontend/src/components/Problem/ProblemSolveContainer.tsx
+++ b/frontend/src/components/Problem/ProblemSolveContainer.tsx
@@ -105,19 +105,17 @@ export function ProblemSolveContainer({
     submission.submit(form);
   }
 
-  const handleScoreResult = (
-    data: ScoreResult & {
-      testcaseId: number;
-    },
-  ) => {
-    const { problemId, result, stdout, testcaseId } = data;
+  const handleScoreResult = (data: ScoreResult) => {
+    const { problemId, result, memoryUsage, timeUsage, testcaseId } = data;
     const newResult = {
       testcaseId,
       submitState: SUBMIT_STATE.submitted,
       score: {
         problemId,
+        testcaseId,
         result,
-        stdout,
+        memoryUsage,
+        timeUsage,
       } satisfies ScoreResult,
     };
     submission.changeDoneScoreResult(newResult);

--- a/frontend/src/components/Submission/Score.tsx
+++ b/frontend/src/components/Submission/Score.tsx
@@ -35,7 +35,7 @@ export default function Score({ testcaseId, score, submitState }: Props) {
         size="lg"
         className={resultTextStyle({ status: isSuccess ? 'success' : 'failed' })}
       >
-        {score?.result ?? ''} ({score?.stdOut ?? ''})
+        {score?.result ?? ''} ({score?.stdout ?? ''})
       </Text.Body>
     </VStack>
   );

--- a/frontend/src/components/Submission/Score.tsx
+++ b/frontend/src/components/Submission/Score.tsx
@@ -36,7 +36,7 @@ export default function Score({ testcaseId, score, submitState }: Props) {
         size="lg"
         className={resultTextStyle({ status: isSuccess ? 'success' : 'failed' })}
       >
-        {result ?? ''} ({`${byteToKB(memoryUsage)}KB, ${(timeUsage / 1000).toFixed(2)}s`})
+        {result} ({`${byteToKB(memoryUsage)}KB, ${(timeUsage / 1000).toFixed(2)}s`})
       </Text.Body>
     </VStack>
   );

--- a/frontend/src/components/Submission/Score.tsx
+++ b/frontend/src/components/Submission/Score.tsx
@@ -1,6 +1,7 @@
 import { css, cva } from '@style/css';
 
 import { Icon, Text, VStack } from '@/components/Common';
+import { byteToKB } from '@/utils/unit';
 
 import type { ScoreResult, SubmitState } from './types';
 import { SUBMIT_STATE } from './types';
@@ -26,7 +27,7 @@ export default function Score({ testcaseId, score, submitState }: Props) {
   }
 
   const isSuccess = score?.result === '정답입니다';
-
+  const { result = '', memoryUsage = 0, timeUsage = 0 } = score ?? {};
   return (
     <VStack className={style}>
       {isSuccess ? <Icon.CheckRound color="success" /> : <Icon.CancelRound color="danger" />}
@@ -35,7 +36,7 @@ export default function Score({ testcaseId, score, submitState }: Props) {
         size="lg"
         className={resultTextStyle({ status: isSuccess ? 'success' : 'failed' })}
       >
-        {score?.result ?? ''} ({score?.stdout ?? ''})
+        {result ?? ''} ({`${byteToKB(memoryUsage)}KB, ${(timeUsage / 1000).toFixed(2)}s`})
       </Text.Body>
     </VStack>
   );

--- a/frontend/src/components/Submission/types.ts
+++ b/frontend/src/components/Submission/types.ts
@@ -15,8 +15,10 @@ export type ScoreStart = {
 
 export type ScoreResult = {
   problemId: ProblemId;
+  testcaseId: number;
+  timeUsage: number;
+  memoryUsage: number;
   result: string;
-  stdout: string;
 };
 
 export type SubmitResult = {

--- a/frontend/src/components/Submission/types.ts
+++ b/frontend/src/components/Submission/types.ts
@@ -16,7 +16,7 @@ export type ScoreStart = {
 export type ScoreResult = {
   problemId: ProblemId;
   result: string;
-  stdOut: string;
+  stdout: string;
 };
 
 export type SubmitResult = {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,11 +9,11 @@ import { Modal } from './components/Common';
 import router from './router';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <AuthProvider>
-      <Modal.Provider>
-        <RouterProvider router={router}></RouterProvider>
-      </Modal.Provider>
-    </AuthProvider>
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <AuthProvider>
+    <Modal.Provider>
+      <RouterProvider router={router}></RouterProvider>
+    </Modal.Provider>
+  </AuthProvider>,
+  // </React.StrictMode>
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,11 +9,11 @@ import { Modal } from './components/Common';
 import router from './router';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  // <React.StrictMode>
-  <AuthProvider>
-    <Modal.Provider>
-      <RouterProvider router={router}></RouterProvider>
-    </Modal.Provider>
-  </AuthProvider>,
-  // </React.StrictMode>
+  <React.StrictMode>
+    <AuthProvider>
+      <Modal.Provider>
+        <RouterProvider router={router}></RouterProvider>
+      </Modal.Provider>
+    </AuthProvider>
+  </React.StrictMode>,
 );

--- a/frontend/src/utils/unit/__tests__/byteToKb.spec.ts
+++ b/frontend/src/utils/unit/__tests__/byteToKb.spec.ts
@@ -1,0 +1,11 @@
+import { byteToKB } from '../index';
+import { describe, expect, it } from 'vitest';
+
+describe('byteToKB', () => {
+  it('byte를 KB로 변환한다.', () => {
+    expect(byteToKB(0)).toBe(0);
+    expect(byteToKB(1024)).toBe(1);
+    expect(byteToKB(2048)).toBe(2);
+    expect(byteToKB(1024 * 1024)).toBe(1024);
+  });
+});

--- a/frontend/src/utils/unit/index.ts
+++ b/frontend/src/utils/unit/index.ts
@@ -1,0 +1,5 @@
+const KB_BY_BYTES = 1024;
+
+export function byteToKB(byte: number) {
+  return Math.floor(byte / KB_BY_BYTES);
+}


### PR DESCRIPTION
## 한 일

- 제출 결과 시간 및 메모리 사용량 출력
  - 메모리는 KB, 시간은 1000으로 나눈 값을 출력 
- 소켓 이벤트로 problemResult 이벤트를 받아 결과를 알려줌
  - 기존에 맞은 수를 카운트 하여 맞았다고 알려주는 로직은 제거
- 버그 픽스: 원소들이 아래 이미지처럼 정렬되는 버그 수정
 
![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/2d31d80a-8005-4f3c-821d-1ec2d9ba1da1)

- 이유는 VStack에 alignItems를 flexStart를 default로 설정하면서 설정이 없는 원소들이 다르게 동작하는 문제였음

## 스크린 샷
<img width="918" alt="스크린샷 2023-12-12 오전 1 20 03" src="https://github.com/boostcampwm2023/web12-algo-with-me/assets/40891497/960e9134-9537-42af-a0b9-58a050fed535">

맥북 에어 화면에서 깨지네요 홀홀

## 참고

웹소켓 API 변경사항 확인하세요
https://www.notion.so/websocket-8ab0814b081a4f57994818de4c3b9a68?pvs=4