### PR TITLE
[#274] 대시보드 집계페이지 남은시간

### DIFF
--- a/frontend/src/components/Dashboard/DashboardLoading.tsx
+++ b/frontend/src/components/Dashboard/DashboardLoading.tsx
@@ -7,11 +7,11 @@ import Header from '../Header';
 import { PageLayout } from '../Layout/PageLayout';
 
 interface Props {
-  endsAt: string;
+  bufferTimeAfterCompetitionEnd: Date;
 }
 
-export default function DashboardLoading({ endsAt }: Props) {
-  const remainingTime = useRemainingTimeCounter(new Date(endsAt));
+export default function DashboardLoading({ bufferTimeAfterCompetitionEnd }: Props) {
+  const remainingTime = useRemainingTimeCounter(new Date(bufferTimeAfterCompetitionEnd));
 
   return (
     <>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -39,7 +39,7 @@ export default function DashboardPage() {
   );
 
   if (shouldRenderLoading) {
-    return <DashboardLoading endsAt={endsAt} />;
+    return <DashboardLoading bufferTimeAfterCompetitionEnd={bufferTimeAfterCompetitionEnd} />;
   }
 
   return (


### PR DESCRIPTION
### 한 일

대시보드 집계페이지에서 남은시간이 출력되지 않던 걸 수정했습니다.


### 스크린샷

![image](https://github.com/boostcampwm2023/web12-algo-with-me/assets/132538081/c1c437e7-e903-41d2-8e98-929f8d36d55f)
